### PR TITLE
RSA support

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -36,10 +36,10 @@ cd ./wolfssl
 
 if [ "$OS" = "macos" ]; then
     echo "Configuring wolfSSL for macOS..."
-    ./configure --prefix=/opt/wolfssl/ CC=clang --enable-cmac --enable-ed25519 --enable-ed448 --enable-curve25519 --enable-curve448 --enable-aesccm --enable-aesxts
+    ./configure --prefix=/opt/wolfssl/ CC=clang --enable-cmac --enable-ed25519 --enable-ed448 --enable-curve25519 --enable-curve448 --enable-aesccm --enable-aesxts --enable-keygen
 else
     echo "Configuring wolfSSL for Linux..."
-    ./configure --prefix=/opt/wolfssl/ --enable-cmac --enable-ed25519 --enable-ed448 --enable-curve25519 --enable-curve448 --enable-aesccm --enable-aesxts
+    ./configure --prefix=/opt/wolfssl/ --enable-cmac --enable-ed25519 --enable-ed448 --enable-curve25519 --enable-curve448 --enable-aesccm --enable-aesxts --enable-keygen
 fi
 
 make

--- a/wolfssl-gnutls-wrapper/src/gnutls_compat.h
+++ b/wolfssl-gnutls-wrapper/src/gnutls_compat.h
@@ -330,6 +330,19 @@ typedef enum {
 	GNUTLS_EXPORT = 1
 } gnutls_direction_t;
 
+typedef enum gnutls_privkey_flags {
+	GNUTLS_PRIVKEY_IMPORT_AUTO_RELEASE = 1,
+	GNUTLS_PRIVKEY_IMPORT_COPY = 1 << 1,
+	GNUTLS_PRIVKEY_DISABLE_CALLBACKS = 1 << 2,
+	GNUTLS_PRIVKEY_SIGN_FLAG_TLS1_RSA = 1 << 4,
+	GNUTLS_PRIVKEY_FLAG_PROVABLE = 1 << 5,
+	GNUTLS_PRIVKEY_FLAG_EXPORT_COMPAT = 1 << 6,
+	GNUTLS_PRIVKEY_SIGN_FLAG_RSA_PSS = 1 << 7,
+	GNUTLS_PRIVKEY_FLAG_REPRODUCIBLE = 1 << 8,
+	GNUTLS_PRIVKEY_FLAG_CA = 1 << 9,
+	GNUTLS_PRIVKEY_FLAG_RSA_PSS_FIXED_SALT_LENGTH = 1 << 10
+} gnutls_privkey_flags_t;
+
 /* Public key algorithms */
 typedef struct gnutls_crypto_pk {
     gnutls_pk_generate_func generate_backend;

--- a/wolfssl-gnutls-wrapper/src/gnutls_compat.h
+++ b/wolfssl-gnutls-wrapper/src/gnutls_compat.h
@@ -204,6 +204,19 @@ typedef enum {
 	GNUTLS_PK_FLAG_RSA_PSS_FIXED_SALT_LENGTH = 4
 } gnutls_pk_flag_t;
 
+typedef enum gnutls_privkey_flags {
+	GNUTLS_PRIVKEY_IMPORT_AUTO_RELEASE = 1,
+	GNUTLS_PRIVKEY_IMPORT_COPY = 1 << 1,
+	GNUTLS_PRIVKEY_DISABLE_CALLBACKS = 1 << 2,
+	GNUTLS_PRIVKEY_SIGN_FLAG_TLS1_RSA = 1 << 4,
+	GNUTLS_PRIVKEY_FLAG_PROVABLE = 1 << 5,
+	GNUTLS_PRIVKEY_FLAG_EXPORT_COMPAT = 1 << 6,
+	GNUTLS_PRIVKEY_SIGN_FLAG_RSA_PSS = 1 << 7,
+	GNUTLS_PRIVKEY_FLAG_REPRODUCIBLE = 1 << 8,
+	GNUTLS_PRIVKEY_FLAG_CA = 1 << 9,
+	GNUTLS_PRIVKEY_FLAG_RSA_PSS_FIXED_SALT_LENGTH = 1 << 10
+} gnutls_privkey_flags_t;
+
 #define FIX_SIGN_PARAMS(params, flags, dig)                            \
 	do {                                                           \
 		if ((flags) & GNUTLS_PRIVKEY_FLAG_REPRODUCIBLE) {      \
@@ -329,19 +342,6 @@ typedef enum {
 	GNUTLS_IMPORT = 0,
 	GNUTLS_EXPORT = 1
 } gnutls_direction_t;
-
-typedef enum gnutls_privkey_flags {
-	GNUTLS_PRIVKEY_IMPORT_AUTO_RELEASE = 1,
-	GNUTLS_PRIVKEY_IMPORT_COPY = 1 << 1,
-	GNUTLS_PRIVKEY_DISABLE_CALLBACKS = 1 << 2,
-	GNUTLS_PRIVKEY_SIGN_FLAG_TLS1_RSA = 1 << 4,
-	GNUTLS_PRIVKEY_FLAG_PROVABLE = 1 << 5,
-	GNUTLS_PRIVKEY_FLAG_EXPORT_COMPAT = 1 << 6,
-	GNUTLS_PRIVKEY_SIGN_FLAG_RSA_PSS = 1 << 7,
-	GNUTLS_PRIVKEY_FLAG_REPRODUCIBLE = 1 << 8,
-	GNUTLS_PRIVKEY_FLAG_CA = 1 << 9,
-	GNUTLS_PRIVKEY_FLAG_RSA_PSS_FIXED_SALT_LENGTH = 1 << 10
-} gnutls_privkey_flags_t;
 
 /* Public key algorithms */
 typedef struct gnutls_crypto_pk {

--- a/wolfssl-gnutls-wrapper/src/wolfssl.c
+++ b/wolfssl-gnutls-wrapper/src/wolfssl.c
@@ -1646,6 +1646,9 @@ static int get_hash_type(gnutls_mac_algorithm_t algorithm)
         case GNUTLS_MAC_SHA512:
             WGW_LOG("using SHA512 for HMAC");
             return WC_SHA512;
+        case GNUTLS_MAC_MD5_SHA1:
+            WGW_LOG("using MD5_SHA1 for HMAC");
+            return WC_HASH_TYPE_MD5_SHA;
         default:
             return -1;
     }
@@ -4435,6 +4438,10 @@ wolfssl_pk_sign_hash(void *_ctx, const void *signer,
             case WC_HASH_TYPE_SHA512:
                 mgf = WC_MGF1SHA512;
                 WGW_LOG("using MGF1SHA512");
+                break;
+            case WC_HASH_TYPE_MD5_SHA:
+                mgf = WC_MGF1SHA1;
+                WGW_LOG("using MGF1SHA1 as fallback for MD5_SHA1");
                 break;
             default:
                 WGW_LOG("Unsupported hash algorithm: %d", hash_type);

--- a/wolfssl-gnutls-wrapper/tests/Makefile
+++ b/wolfssl-gnutls-wrapper/tests/Makefile
@@ -1,4 +1,4 @@
-TESTS = test_sha256 test_aescbc test_aesgcm test_hmac test_ecdsa_sign_and_verify test_ecdh_encrypt_and_decrypt test_eddsa_sign_and_verify
+TESTS = test_sha256 test_aescbc test_aesgcm test_hmac test_ecdsa_sign_and_verify test_rsa_sign_and_verify test_ecdh_encrypt_and_decrypt test_eddsa_sign_and_verify
 
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
@@ -49,6 +49,9 @@ test_eddsa_sign_and_verify: test_eddsa_sign_and_verify.c
 	$(CC) -g -o $@ $< $(INCLUDES) $(LDFLAGS) $(LIBS)
 
 test_ecdh_encrypt_and_decrypt: test_ecdh_encrypt_and_decrypt.c
+	$(CC) -g -o $@ $< $(INCLUDES) $(LDFLAGS) $(LIBS)
+
+test_rsa_sign_and_verify: test_rsa_sign_and_verify.c
 	$(CC) -g -o $@ $< $(INCLUDES) $(LDFLAGS) $(LIBS)
 
 run-%:

--- a/wolfssl-gnutls-wrapper/tests/Makefile
+++ b/wolfssl-gnutls-wrapper/tests/Makefile
@@ -1,4 +1,4 @@
-TESTS = test_sha256 test_aescbc test_aesgcm test_hmac test_ecdsa_sign_and_verify test_rsa_sign_and_verify test_ecdh_encrypt_and_decrypt test_eddsa_sign_and_verify
+TESTS = test_sha256 test_aescbc test_aesgcm test_hmac test_ecdsa_sign_and_verify test_rsa_sign_and_verify test_ecdh_encrypt_and_decrypt test_rsa_encrypt_and_decrypt test_eddsa_sign_and_verify
 
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
@@ -52,6 +52,9 @@ test_ecdh_encrypt_and_decrypt: test_ecdh_encrypt_and_decrypt.c
 	$(CC) -g -o $@ $< $(INCLUDES) $(LDFLAGS) $(LIBS)
 
 test_rsa_sign_and_verify: test_rsa_sign_and_verify.c
+	$(CC) -g -o $@ $< $(INCLUDES) $(LDFLAGS) $(LIBS)
+
+test_rsa_encrypt_and_decrypt: test_rsa_encrypt_and_decrypt.c
 	$(CC) -g -o $@ $< $(INCLUDES) $(LDFLAGS) $(LIBS)
 
 run-%:

--- a/wolfssl-gnutls-wrapper/tests/test_rsa_encrypt_and_decrypt.c
+++ b/wolfssl-gnutls-wrapper/tests/test_rsa_encrypt_and_decrypt.c
@@ -1,0 +1,180 @@
+#include <stdio.h>
+#include <string.h>
+#include <gnutls/gnutls.h>
+#include <gnutls/abstract.h>
+#include <gnutls/crypto.h>
+#include <dlfcn.h>
+
+void print_hex(const unsigned char *data, size_t len) {
+    for (size_t i = 0; i < len; i++) {
+        printf("%02x", data[i]);
+        if ((i+1) % 16 == 0 && i != len - 1)
+            printf("\n");
+        else if ((i+1) % 8 == 0 && i != len - 1)
+            printf(" ");
+        else if (i != len - 1)
+            printf(" ");
+    }
+    printf("\n");
+}
+
+int test_rsa_encrypt_decrypt(unsigned int bits) {
+    int ret;
+    gnutls_privkey_t privkey;
+    gnutls_pubkey_t pubkey;
+    gnutls_datum_t ciphertext;
+    gnutls_datum_t decrypted;
+    const char *test_data = "Test data to be encrypted with RSA";
+    gnutls_datum_t data = { (unsigned char *)test_data, strlen(test_data) };
+
+    memset(&ciphertext, 0, sizeof(ciphertext));
+    memset(&decrypted, 0, sizeof(decrypted));
+
+    printf("\n=== Testing RSA encryption/decryption with %d bits ===\n", bits);
+
+    /* Initialize keys */
+    ret = gnutls_privkey_init(&privkey);
+    if (ret != 0) {
+        printf("Error initializing private key: %s\n", gnutls_strerror(ret));
+        return 1;
+    }
+
+    ret = gnutls_pubkey_init(&pubkey);
+    if (ret != 0) {
+        printf("Error initializing public key: %s\n", gnutls_strerror(ret));
+        gnutls_privkey_deinit(privkey);
+        return 1;
+    }
+
+    /* Generate an RSA key pair with the specified size */
+    printf("Generating RSA key pair (%d bits)...\n", bits);
+    ret = gnutls_privkey_generate2(privkey, GNUTLS_PK_RSA,
+            bits,
+            0, NULL, 0);
+    if (ret != 0) {
+        printf("Error generating private key: %s\n", gnutls_strerror(ret));
+        gnutls_pubkey_deinit(pubkey);
+        gnutls_privkey_deinit(privkey);
+        return 1;
+    }
+
+    /* Extract the public key from the private key */
+    ret = gnutls_pubkey_import_privkey(pubkey, privkey, 0, 0);
+    if (ret != 0) {
+        printf("Error extracting public key: %s\n", gnutls_strerror(ret));
+        gnutls_pubkey_deinit(pubkey);
+        gnutls_privkey_deinit(privkey);
+        return 1;
+    }
+
+    /* Encrypt the test data */
+    printf("Original data: \"%s\"\n", test_data);
+    ret = gnutls_pubkey_encrypt_data(pubkey, 0, &data, &ciphertext);
+    if (ret != 0) {
+        printf("Error encrypting data: %s\n", gnutls_strerror(ret));
+        gnutls_pubkey_deinit(pubkey);
+        gnutls_privkey_deinit(privkey);
+        return 1;
+    }
+
+    printf("Encrypted data (size: %d bytes)\n", ciphertext.size);
+    printf("Encrypted value:\n");
+    print_hex(ciphertext.data, ciphertext.size);
+
+    /* Decrypt the data */
+    printf("Decrypting data...\n");
+    ret = gnutls_privkey_decrypt_data(privkey, 0, &ciphertext, &decrypted);
+    if (ret != 0) {
+        printf("Error decrypting data: %s\n", gnutls_strerror(ret));
+        gnutls_free(ciphertext.data);
+        gnutls_pubkey_deinit(pubkey);
+        gnutls_privkey_deinit(privkey);
+        return 1;
+    }
+
+    /* Verify decryption worked correctly */
+    if (decrypted.size != data.size || 
+        memcmp(decrypted.data, data.data, data.size) != 0) {
+        printf("FAILURE: Decrypted data doesn't match original for RSA %d bits\n", bits);
+        gnutls_free(ciphertext.data);
+        gnutls_free(decrypted.data);
+        gnutls_pubkey_deinit(pubkey);
+        gnutls_privkey_deinit(privkey);
+        return 1;
+    }
+    
+    printf("Decrypted data: \"%.*s\"\n", (int)decrypted.size, (char *)decrypted.data);
+    printf("SUCCESS for RSA %d bits\n", bits);
+
+    /* Test the fixed length API */
+    printf("\nTesting fixed length API...\n");
+    unsigned char fixed_buffer[512]; /* Large enough buffer for any RSA key size we test */
+    size_t fixed_size = sizeof(fixed_buffer);
+    
+    memset(fixed_buffer, 0, fixed_size);
+    
+    ret = gnutls_privkey_decrypt_data2(privkey, 0, &ciphertext, fixed_buffer, fixed_size);
+    if (ret != 0) {
+        printf("Error using fixed length decrypt API: %s\n", gnutls_strerror(ret));
+        gnutls_free(ciphertext.data);
+        gnutls_free(decrypted.data);
+        gnutls_pubkey_deinit(pubkey);
+        gnutls_privkey_deinit(privkey);
+        return 1;
+    }
+    
+    if (memcmp(fixed_buffer, data.data, data.size) != 0) {
+        printf("FAILURE: Fixed length API decrypted data doesn't match original\n");
+        gnutls_free(ciphertext.data);
+        gnutls_free(decrypted.data);
+        gnutls_pubkey_deinit(pubkey);
+        gnutls_privkey_deinit(privkey);
+        return 1;
+    }
+    
+    printf("Fixed length API SUCCESS\n");
+
+    /* Clean up */
+    gnutls_free(ciphertext.data);
+    gnutls_free(decrypted.data);
+    gnutls_pubkey_deinit(pubkey);
+    gnutls_privkey_deinit(privkey);
+
+    return 0;
+}
+
+int main(void) {
+    int ret;
+
+    printf("Testing GnuTLS's RSA encryption/decryption with multiple key sizes...\n");
+
+    /* Initialize GnuTLS */
+    ret = gnutls_global_init();
+    if (ret != 0) {
+        printf("Error initializing GnuTLS: %s\n", gnutls_strerror(ret));
+        return 1;
+    }
+
+    /* Test standard RSA with different key sizes */
+    printf("\n--- Testing RSA Encryption/Decryption ---\n");
+
+    /* Test 2048-bit RSA */
+    ret = test_rsa_encrypt_decrypt(2048);
+    if (ret != 0) {
+        gnutls_global_deinit();
+        return 1;
+    }
+
+    /* Test 4096-bit RSA */
+    ret = test_rsa_encrypt_decrypt(4096);
+    if (ret != 0) {
+        gnutls_global_deinit();
+        return 1;
+    }
+
+    /* Clean up global resources */
+    gnutls_global_deinit();
+
+    printf("\nAll RSA encryption/decryption tests completed successfully!\n");
+    return 0;
+}

--- a/wolfssl-gnutls-wrapper/tests/test_rsa_sign_and_verify.c
+++ b/wolfssl-gnutls-wrapper/tests/test_rsa_sign_and_verify.c
@@ -1,0 +1,267 @@
+#include <stdio.h>
+#include <string.h>
+#include <gnutls/gnutls.h>
+#include <gnutls/abstract.h>
+#include <gnutls/crypto.h>
+#include <dlfcn.h>
+
+void print_hex(const unsigned char *data, size_t len) {
+    for (size_t i = 0; i < len; i++) {
+        printf("%02x", data[i]);
+        if ((i+1) % 16 == 0 && i != len - 1)
+            printf("\n");
+        else if ((i+1) % 8 == 0 && i != len - 1)
+            printf(" ");
+        else if (i != len - 1)
+            printf(" ");
+    }
+    printf("\n");
+}
+
+int test_rsa_key_size(unsigned int bits) {
+    int ret;
+    gnutls_privkey_t privkey;
+    gnutls_pubkey_t pubkey;
+    gnutls_datum_t signature;
+    const char *test_data = "Test data to be signed";
+    gnutls_datum_t data = { (unsigned char *)test_data, strlen(test_data) };
+    gnutls_digest_algorithm_t digest_algo;
+    gnutls_sign_algorithm_t sign_algo;
+
+    /* Select appropriate digest algorithm based on key size */
+    if (bits <= 2048) {
+        digest_algo = GNUTLS_DIG_SHA256;
+        sign_algo = GNUTLS_SIGN_RSA_SHA256;
+    } else if (bits <= 3072) {
+        digest_algo = GNUTLS_DIG_SHA384;
+        sign_algo = GNUTLS_SIGN_RSA_SHA384;
+    } else {
+        digest_algo = GNUTLS_DIG_SHA512;
+        sign_algo = GNUTLS_SIGN_RSA_SHA512;
+    }
+
+    memset(&signature, 0, sizeof(signature));
+
+    printf("\n=== Testing RSA with %d bits ===\n", bits);
+
+    /* Initialize keys */
+    ret = gnutls_privkey_init(&privkey);
+    if (ret != 0) {
+        printf("Error initializing private key: %s\n", gnutls_strerror(ret));
+        return 1;
+    }
+
+    ret = gnutls_pubkey_init(&pubkey);
+    if (ret != 0) {
+        printf("Error initializing public key: %s\n", gnutls_strerror(ret));
+        gnutls_privkey_deinit(privkey);
+        return 1;
+    }
+
+    /* Generate an RSA key pair with the specified size */
+    printf("Generating RSA key pair (%d bits)...\n", bits);
+    ret = gnutls_privkey_generate2(privkey, GNUTLS_PK_RSA,
+            bits,
+            0, NULL, 0);
+    if (ret != 0) {
+        printf("Error generating private key: %s\n", gnutls_strerror(ret));
+        gnutls_pubkey_deinit(pubkey);
+        gnutls_privkey_deinit(privkey);
+        return 1;
+    }
+
+    /* Extract the public key from the private key */
+    ret = gnutls_pubkey_import_privkey(pubkey, privkey, 0, 0);
+    if (ret != 0) {
+        printf("Error extracting public key: %s\n", gnutls_strerror(ret));
+        gnutls_pubkey_deinit(pubkey);
+        gnutls_privkey_deinit(privkey);
+        return 1;
+    }
+
+    /* Sign the test data */
+    printf("input data: \"%s\"\n", test_data);
+    ret = gnutls_privkey_sign_data(privkey, digest_algo, 0, &data, &signature);
+    if (ret != 0) {
+        printf("Error signing data: %s\n", gnutls_strerror(ret));
+        gnutls_pubkey_deinit(pubkey);
+        gnutls_privkey_deinit(privkey);
+        return 1;
+    }
+
+    printf("Signature created (size: %d bytes)\n", signature.size);
+    printf("Signature value:\n");
+    print_hex(signature.data, signature.size);
+
+    /* Verify the signature */
+    printf("Verifying signature...\n");
+    ret = gnutls_pubkey_verify_data2(pubkey, sign_algo,
+            0, &data, &signature);
+    if (ret == 0) {
+        printf("SUCCESS for RSA %d bits\n", bits);
+    } else {
+        printf("FAILURE for RSA %d bits: %s\n", bits, gnutls_strerror(ret));
+        gnutls_free(signature.data);
+        gnutls_pubkey_deinit(pubkey);
+        gnutls_privkey_deinit(privkey);
+        return 1;
+    }
+
+    /* Clean up */
+    gnutls_free(signature.data);
+    gnutls_pubkey_deinit(pubkey);
+    gnutls_privkey_deinit(privkey);
+
+    return 0;
+}
+
+int test_rsa_pss_key_size(unsigned int bits) {
+    int ret;
+    gnutls_privkey_t privkey;
+    gnutls_pubkey_t pubkey;
+    gnutls_datum_t signature;
+    const char *test_data = "Test data to be signed with RSA-PSS";
+    gnutls_datum_t data = { (unsigned char *)test_data, strlen(test_data) };
+    gnutls_digest_algorithm_t digest_algo;
+    gnutls_sign_algorithm_t sign_algo;
+
+    /* Select appropriate digest algorithm based on key size */
+    if (bits <= 2048) {
+        digest_algo = GNUTLS_DIG_SHA256;
+        sign_algo = GNUTLS_SIGN_RSA_PSS_SHA256;
+    } else if (bits <= 3072) {
+        digest_algo = GNUTLS_DIG_SHA384;
+        sign_algo = GNUTLS_SIGN_RSA_PSS_SHA384;
+    } else {
+        digest_algo = GNUTLS_DIG_SHA512;
+        sign_algo = GNUTLS_SIGN_RSA_PSS_SHA512;
+    }
+
+    memset(&signature, 0, sizeof(signature));
+
+    printf("\n=== Testing RSA-PSS with %d bits ===\n", bits);
+
+    /* Initialize keys */
+    ret = gnutls_privkey_init(&privkey);
+    if (ret != 0) {
+        printf("Error initializing private key: %s\n", gnutls_strerror(ret));
+        return 1;
+    }
+
+    ret = gnutls_pubkey_init(&pubkey);
+    if (ret != 0) {
+        printf("Error initializing public key: %s\n", gnutls_strerror(ret));
+        gnutls_privkey_deinit(privkey);
+        return 1;
+    }
+
+    /* Generate an RSA-PSS key pair with the specified size */
+    printf("Generating RSA-PSS key pair (%d bits)...\n", bits);
+    ret = gnutls_privkey_generate2(privkey, GNUTLS_PK_RSA_PSS,
+            bits,
+            0, NULL, 0);
+    if (ret != 0) {
+        printf("Error generating private key: %s\n", gnutls_strerror(ret));
+        gnutls_pubkey_deinit(pubkey);
+        gnutls_privkey_deinit(privkey);
+        return 1;
+    }
+
+    /* Extract the public key from the private key */
+    ret = gnutls_pubkey_import_privkey(pubkey, privkey, 0, 0);
+    if (ret != 0) {
+        printf("Error extracting public key: %s\n", gnutls_strerror(ret));
+        gnutls_pubkey_deinit(pubkey);
+        gnutls_privkey_deinit(privkey);
+        return 1;
+    }
+
+    /* Sign the test data */
+    printf("input data: \"%s\"\n", test_data);
+    ret = gnutls_privkey_sign_data(privkey, digest_algo, 0, &data, &signature);
+    if (ret != 0) {
+        printf("Error signing data: %s\n", gnutls_strerror(ret));
+        gnutls_pubkey_deinit(pubkey);
+        gnutls_privkey_deinit(privkey);
+        return 1;
+    }
+
+    printf("Signature created (size: %d bytes)\n", signature.size);
+    printf("Signature value:\n");
+    print_hex(signature.data, signature.size);
+
+    /* Verify the signature */
+    printf("Verifying signature...\n");
+    ret = gnutls_pubkey_verify_data2(pubkey, sign_algo,
+            0, &data, &signature);
+    if (ret == 0) {
+        printf("SUCCESS for RSA-PSS %d bits\n", bits);
+    } else {
+        printf("FAILURE for RSA-PSS %d bits: %s\n", bits, gnutls_strerror(ret));
+        gnutls_free(signature.data);
+        gnutls_pubkey_deinit(pubkey);
+        gnutls_privkey_deinit(privkey);
+        return 1;
+    }
+
+    /* Clean up */
+    gnutls_free(signature.data);
+    gnutls_pubkey_deinit(pubkey);
+    gnutls_privkey_deinit(privkey);
+
+    return 0;
+}
+
+int main(void) {
+    int ret;
+
+    printf("Testing GnuTLS's RSA and RSA-PSS implementations with multiple key sizes...\n");
+
+    /* Initialize GnuTLS */
+    ret = gnutls_global_init();
+    if (ret != 0) {
+        printf("Error initializing GnuTLS: %s\n", gnutls_strerror(ret));
+        return 1;
+    }
+
+    /* Test standard RSA */
+    printf("\n--- Testing Standard RSA ---\n");
+
+    /* Test 2048-bit RSA */
+    ret = test_rsa_key_size(2048);
+    if (ret != 0) {
+        gnutls_global_deinit();
+        return 1;
+    }
+
+    /* Test 4096-bit RSA */
+    ret = test_rsa_key_size(4096);
+    if (ret != 0) {
+        gnutls_global_deinit();
+        return 1;
+    }
+
+    /* Test RSA-PSS */
+    printf("\n--- Testing RSA-PSS ---\n");
+
+    /* Test 2048-bit RSA-PSS */
+    ret = test_rsa_pss_key_size(2048);
+    if (ret != 0) {
+        gnutls_global_deinit();
+        return 1;
+    }
+
+
+    /* Test 4096-bit RSA-PSS */
+    ret = test_rsa_pss_key_size(4096);
+    if (ret != 0) {
+        gnutls_global_deinit();
+        return 1;
+    }
+
+    /* Clean up global resources */
+    gnutls_global_deinit();
+
+    printf("\nAll RSA and RSA-PSS key size tests completed successfully!\n");
+    return 0;
+}

--- a/wolfssl-gnutls-wrapper/tests/test_rsa_sign_and_verify.c
+++ b/wolfssl-gnutls-wrapper/tests/test_rsa_sign_and_verify.c
@@ -22,11 +22,13 @@ int test_rsa_key_size(unsigned int bits) {
     int ret;
     gnutls_privkey_t privkey;
     gnutls_pubkey_t pubkey;
-    gnutls_datum_t signature;
+    gnutls_datum_t signature, signature_hash;
     const char *test_data = "Test data to be signed";
     gnutls_datum_t data = { (unsigned char *)test_data, strlen(test_data) };
     gnutls_digest_algorithm_t digest_algo;
     gnutls_sign_algorithm_t sign_algo;
+    unsigned char hash_buffer[64]; // Big enough for any hash we'll use
+    gnutls_datum_t hash;
 
     /* Select appropriate digest algorithm based on key size */
     if (bits <= 2048) {
@@ -41,6 +43,8 @@ int test_rsa_key_size(unsigned int bits) {
     }
 
     memset(&signature, 0, sizeof(signature));
+    memset(&signature_hash, 0, sizeof(signature_hash));
+    memset(hash_buffer, 0, sizeof(hash_buffer));
 
     printf("\n=== Testing RSA with %d bits ===\n", bits);
 
@@ -58,7 +62,7 @@ int test_rsa_key_size(unsigned int bits) {
         return 1;
     }
 
-    /* Generate an RSA key pair with the specified size */
+    /* Generate an RSA key pair */
     printf("Generating RSA key pair (%d bits)...\n", bits);
     ret = gnutls_privkey_generate2(privkey, GNUTLS_PK_RSA,
             bits,
@@ -70,7 +74,7 @@ int test_rsa_key_size(unsigned int bits) {
         return 1;
     }
 
-    /* Extract the public key from the private key */
+    /* Extract the public key */
     ret = gnutls_pubkey_import_privkey(pubkey, privkey, 0, 0);
     if (ret != 0) {
         printf("Error extracting public key: %s\n", gnutls_strerror(ret));
@@ -79,8 +83,10 @@ int test_rsa_key_size(unsigned int bits) {
         return 1;
     }
 
-    /* Sign the test data */
+    /* Test 1: Sign and verify raw data */
+    printf("\n--- Test 1: Sign/Verify Raw Data ---\n");
     printf("input data: \"%s\"\n", test_data);
+    
     ret = gnutls_privkey_sign_data(privkey, digest_algo, 0, &data, &signature);
     if (ret != 0) {
         printf("Error signing data: %s\n", gnutls_strerror(ret));
@@ -89,26 +95,70 @@ int test_rsa_key_size(unsigned int bits) {
         return 1;
     }
 
-    printf("Signature created (size: %d bytes)\n", signature.size);
-    printf("Signature value:\n");
+    printf("Data signature created (size: %d bytes)\n", signature.size);
+    printf("Data signature value:\n");
     print_hex(signature.data, signature.size);
 
-    /* Verify the signature */
-    printf("Verifying signature...\n");
-    ret = gnutls_pubkey_verify_data2(pubkey, sign_algo,
-            0, &data, &signature);
-    if (ret == 0) {
-        printf("SUCCESS for RSA %d bits\n", bits);
-    } else {
-        printf("FAILURE for RSA %d bits: %s\n", bits, gnutls_strerror(ret));
+    printf("Verifying data signature...\n");
+    ret = gnutls_pubkey_verify_data2(pubkey, sign_algo, 0, &data, &signature);
+    if (ret != 0) {
+        printf("FAILURE verifying data signature for RSA %d bits: %s\n", bits, gnutls_strerror(ret));
+        gnutls_free(signature.data);
+        gnutls_pubkey_deinit(pubkey);
+        gnutls_privkey_deinit(privkey);
+        return 1;
+    }
+    printf("SUCCESS verifying data signature for RSA %d bits\n", bits);
+
+    /* Test 2: Sign and verify hash */
+    printf("\n--- Test 2: Sign/Verify Hash ---\n");
+    
+    /* Hash the test data */
+    ret = gnutls_hash_fast(digest_algo, data.data, data.size, hash_buffer);
+    if (ret != 0) {
+        printf("Error hashing data: %s\n", gnutls_strerror(ret));
         gnutls_free(signature.data);
         gnutls_pubkey_deinit(pubkey);
         gnutls_privkey_deinit(privkey);
         return 1;
     }
 
+    hash.data = hash_buffer;
+    hash.size = gnutls_hash_get_len(digest_algo);
+
+    printf("Hash value:\n");
+    print_hex(hash.data, hash.size);
+
+    /* Sign the hash */
+    ret = gnutls_privkey_sign_hash(privkey, digest_algo, 0, &hash, &signature_hash);
+    if (ret != 0) {
+        printf("Error signing hash: %s\n", gnutls_strerror(ret));
+        gnutls_free(signature.data);
+        gnutls_pubkey_deinit(pubkey);
+        gnutls_privkey_deinit(privkey);
+        return 1;
+    }
+
+    printf("Hash signature created (size: %d bytes)\n", signature_hash.size);
+    printf("Hash signature value:\n");
+    print_hex(signature_hash.data, signature_hash.size);
+
+    /* Verify the hash signature */
+    printf("Verifying hash signature...\n");
+    ret = gnutls_pubkey_verify_hash2(pubkey, sign_algo, 0, &hash, &signature_hash);
+    if (ret != 0) {
+        printf("FAILURE verifying hash signature for RSA %d bits: %s\n", bits, gnutls_strerror(ret));
+        gnutls_free(signature.data);
+        gnutls_free(signature_hash.data);
+        gnutls_pubkey_deinit(pubkey);
+        gnutls_privkey_deinit(privkey);
+        return 1;
+    }
+    printf("SUCCESS verifying hash signature for RSA %d bits\n", bits);
+
     /* Clean up */
     gnutls_free(signature.data);
+    gnutls_free(signature_hash.data);
     gnutls_pubkey_deinit(pubkey);
     gnutls_privkey_deinit(privkey);
 
@@ -119,11 +169,13 @@ int test_rsa_pss_key_size(unsigned int bits) {
     int ret;
     gnutls_privkey_t privkey;
     gnutls_pubkey_t pubkey;
-    gnutls_datum_t signature;
+    gnutls_datum_t signature, signature_hash;
     const char *test_data = "Test data to be signed with RSA-PSS";
     gnutls_datum_t data = { (unsigned char *)test_data, strlen(test_data) };
     gnutls_digest_algorithm_t digest_algo;
     gnutls_sign_algorithm_t sign_algo;
+    unsigned char hash_buffer[64]; // Big enough for any hash we'll use
+    gnutls_datum_t hash;
 
     /* Select appropriate digest algorithm based on key size */
     if (bits <= 2048) {
@@ -138,6 +190,8 @@ int test_rsa_pss_key_size(unsigned int bits) {
     }
 
     memset(&signature, 0, sizeof(signature));
+    memset(&signature_hash, 0, sizeof(signature_hash));
+    memset(hash_buffer, 0, sizeof(hash_buffer));
 
     printf("\n=== Testing RSA-PSS with %d bits ===\n", bits);
 
@@ -155,7 +209,7 @@ int test_rsa_pss_key_size(unsigned int bits) {
         return 1;
     }
 
-    /* Generate an RSA-PSS key pair with the specified size */
+    /* Generate an RSA-PSS key pair */
     printf("Generating RSA-PSS key pair (%d bits)...\n", bits);
     ret = gnutls_privkey_generate2(privkey, GNUTLS_PK_RSA_PSS,
             bits,
@@ -167,7 +221,7 @@ int test_rsa_pss_key_size(unsigned int bits) {
         return 1;
     }
 
-    /* Extract the public key from the private key */
+    /* Extract the public key */
     ret = gnutls_pubkey_import_privkey(pubkey, privkey, 0, 0);
     if (ret != 0) {
         printf("Error extracting public key: %s\n", gnutls_strerror(ret));
@@ -176,8 +230,10 @@ int test_rsa_pss_key_size(unsigned int bits) {
         return 1;
     }
 
-    /* Sign the test data */
+    /* Test 1: Sign and verify raw data */
+    printf("\n--- Test 1: Sign/Verify Raw Data ---\n");
     printf("input data: \"%s\"\n", test_data);
+    
     ret = gnutls_privkey_sign_data(privkey, digest_algo, 0, &data, &signature);
     if (ret != 0) {
         printf("Error signing data: %s\n", gnutls_strerror(ret));
@@ -186,26 +242,70 @@ int test_rsa_pss_key_size(unsigned int bits) {
         return 1;
     }
 
-    printf("Signature created (size: %d bytes)\n", signature.size);
-    printf("Signature value:\n");
+    printf("Data signature created (size: %d bytes)\n", signature.size);
+    printf("Data signature value:\n");
     print_hex(signature.data, signature.size);
 
-    /* Verify the signature */
-    printf("Verifying signature...\n");
-    ret = gnutls_pubkey_verify_data2(pubkey, sign_algo,
-            0, &data, &signature);
-    if (ret == 0) {
-        printf("SUCCESS for RSA-PSS %d bits\n", bits);
-    } else {
-        printf("FAILURE for RSA-PSS %d bits: %s\n", bits, gnutls_strerror(ret));
+    printf("Verifying data signature...\n");
+    ret = gnutls_pubkey_verify_data2(pubkey, sign_algo, 0, &data, &signature);
+    if (ret != 0) {
+        printf("FAILURE verifying data signature for RSA-PSS %d bits: %s\n", bits, gnutls_strerror(ret));
+        gnutls_free(signature.data);
+        gnutls_pubkey_deinit(pubkey);
+        gnutls_privkey_deinit(privkey);
+        return 1;
+    }
+    printf("SUCCESS verifying data signature for RSA-PSS %d bits\n", bits);
+
+    /* Test 2: Sign and verify hash */
+    printf("\n--- Test 2: Sign/Verify Hash ---\n");
+    
+    /* Hash the test data */
+    ret = gnutls_hash_fast(digest_algo, data.data, data.size, hash_buffer);
+    if (ret != 0) {
+        printf("Error hashing data: %s\n", gnutls_strerror(ret));
         gnutls_free(signature.data);
         gnutls_pubkey_deinit(pubkey);
         gnutls_privkey_deinit(privkey);
         return 1;
     }
 
+    hash.data = hash_buffer;
+    hash.size = gnutls_hash_get_len(digest_algo);
+
+    printf("Hash value:\n");
+    print_hex(hash.data, hash.size);
+
+    /* Sign the hash */
+    ret = gnutls_privkey_sign_hash(privkey, digest_algo, 0, &hash, &signature_hash);
+    if (ret != 0) {
+        printf("Error signing hash: %s\n", gnutls_strerror(ret));
+        gnutls_free(signature.data);
+        gnutls_pubkey_deinit(pubkey);
+        gnutls_privkey_deinit(privkey);
+        return 1;
+    }
+
+    printf("Hash signature created (size: %d bytes)\n", signature_hash.size);
+    printf("Hash signature value:\n");
+    print_hex(signature_hash.data, signature_hash.size);
+
+    /* Verify the hash signature */
+    printf("Verifying hash signature...\n");
+    ret = gnutls_pubkey_verify_hash2(pubkey, sign_algo, 0, &hash, &signature_hash);
+    if (ret != 0) {
+        printf("FAILURE verifying hash signature for RSA-PSS %d bits: %s\n", bits, gnutls_strerror(ret));
+        gnutls_free(signature.data);
+        gnutls_free(signature_hash.data);
+        gnutls_pubkey_deinit(pubkey);
+        gnutls_privkey_deinit(privkey);
+        return 1;
+    }
+    printf("SUCCESS verifying hash signature for RSA-PSS %d bits\n", bits);
+
     /* Clean up */
     gnutls_free(signature.data);
+    gnutls_free(signature_hash.data);
     gnutls_pubkey_deinit(pubkey);
     gnutls_privkey_deinit(privkey);
 


### PR DESCRIPTION
- Support for RSA for sign/verify operations (raw data and hashed) (PSS, PKCS#1 v1.5 and PSS variants mapped in gnutls);
- Local tests test_rsa_encrypt_and_decrypt.c test_rsa_sign_and_verify.c (2048 and 4096 bits), also extended algo the sign/verify test to also test the sign/verify on hashed messages;
- Various bug fixing after RSA support was added, particularly added a copy_backend call when pk algo is figured out after parsing of a certificate in DER or PEM format;