### PR TITLE
Fixes to PK code

### DIFF
--- a/rebuild-gnutls.sh
+++ b/rebuild-gnutls.sh
@@ -28,7 +28,7 @@ if [ "$OS" = "macos" ]; then
     echo "Configuring GnuTLS for macOS..."
     autoreconf -fvi
 
-    CONFIG_OPTS="--prefix=/opt/gnutls/ --disable-doc --disable-manpages --disable-gtk-doc --disable-full-test-suite --disable-valgrind-tests --disable-dependency-tracking --disable-gost --enable-srp-authentication"
+    CONFIG_OPTS="--prefix=/opt/gnutls/ --disable-doc --disable-manpages --disable-gtk-doc --disable-full-test-suite --disable-valgrind-tests --disable-dependency-tracking --disable-gost --disable-dsa --enable-srp-authentication"
 
     if [ $FIPS_MODE -eq 1 ]; then
         CONFIG_OPTS="$CONFIG_OPTS --enable-fips140-mode"
@@ -48,7 +48,7 @@ else
     echo "Configuring GnuTLS for Linux..."
     autoreconf -fvi
 
-    CONFIG_OPTS="--prefix=/opt/gnutls/ --disable-doc --disable-manpages --disable-gtk-doc --disable-gost --enable-srp-authentication"
+    CONFIG_OPTS="--prefix=/opt/gnutls/ --disable-doc --disable-manpages --disable-gtk-doc --disable-gost --disable-dsa --enable-srp-authentication"
 
     if [ $FIPS_MODE -eq 1 ]; then
         CONFIG_OPTS="$CONFIG_OPTS --enable-fips140-mode"

--- a/setup.sh
+++ b/setup.sh
@@ -109,7 +109,7 @@ if [ "$OS" = "macos" ]; then
     echo "Configuring GnuTLS for macOS..."
 
     # Base configuration options
-    CONFIG_OPTS="--prefix=/opt/gnutls/ --disable-doc --disable-manpages --disable-gtk-doc --disable-full-test-suite --disable-valgrind-tests --disable-dependency-tracking --disable-gost --enable-srp-authentication"
+    CONFIG_OPTS="--prefix=/opt/gnutls/ --disable-doc --disable-manpages --disable-gtk-doc --disable-full-test-suite --disable-valgrind-tests --disable-dependency-tracking --disable-gost --disable-dsa --enable-srp-authentication"
 
     # Add FIPS mode if requested
     if [ $FIPS_MODE -eq 1 ]; then
@@ -130,7 +130,7 @@ else
     echo "Configuring GnuTLS for Linux..."
 
     # Base configuration options
-    CONFIG_OPTS="--prefix=/opt/gnutls/ --disable-doc --disable-manpages --disable-gtk-doc --disable-gost --disable-full-test-suite --disable-valgrind-tests --disable-dependency-tracking --enable-srp-authentication"
+    CONFIG_OPTS="--prefix=/opt/gnutls/ --disable-doc --disable-manpages --disable-gtk-doc --disable-gost --disable-dsa --disable-full-test-suite --disable-valgrind-tests --disable-dependency-tracking --enable-srp-authentication"
 
     # Add FIPS mode if requested
     if [ $FIPS_MODE -eq 1 ]; then

--- a/wolfssl-gnutls-wrapper/src/gnutls_compat.h
+++ b/wolfssl-gnutls-wrapper/src/gnutls_compat.h
@@ -3,21 +3,9 @@
 #define MAX_PVP_SEED_SIZE 256
 #include <stdint.h>
 #include <gnutls/crypto.h>
+#include <gnutls/x509.h>
 
 /* replicated definitions from GnuTLS internal headers */
-
-typedef enum {
-    GNUTLS_KEYGEN_SEED = 1,
-    GNUTLS_KEYGEN_DIGEST = 2,
-    GNUTLS_KEYGEN_SPKI = 3,
-    GNUTLS_KEYGEN_DH = 4
-} gnutls_keygen_types_t;
-
-typedef struct {
-    gnutls_keygen_types_t type;
-    unsigned char *data;
-    unsigned int size;
-} gnutls_keygen_data_st;
 
 typedef void *bigint_t;
 


### PR DESCRIPTION
Build GnuTLS without DSA.
Add gnutls/x509.h to includes in gnutls_compat.h and remove duplicate symbols.
Add more signing/verification algorithms - more digest options. When copying private into public, create a random in public key instead of having a copy that is shared. (valgrind issues.) Add DH import public.
Import public data into public key when export private key into public key.
Add support for deterministic ECDSA signing.