### PR TITLE
PK fixes

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -65,7 +65,7 @@ if [ $FIPS_MODE -eq 1 ]; then
 
     cd fips-v5-checkout
 
-    ./configure --prefix=$WOLFSSL_INSTALL/ CC=clang --enable-cmac --enable-aesccm --enable-aescfb --enable-keygen 'CFLAGS=-DWOLFSSL_PUBLIC_ASN -DHAVE_PUBLIC_FFDHE -DHAVE_FFDHE_3072 -DHAVE_FFDHE_4096 -DWOLFSSL_DH_EXTRA -DWOLFSSL_PSS_SALT_LEN_DISCOVER -DWOLFSSL_PUBLIC_MP' --enable-fips=v5
+    ./configure --prefix=$WOLFSSL_INSTALL/ CC=clang --enable-cmac --enable-aesccm --enable-aescfb --enable-keygen 'CFLAGS=-DWOLFSSL_PUBLIC_ASN -DHAVE_PUBLIC_FFDHE -DHAVE_FFDHE_3072 -DHAVE_FFDHE_4096 -DWOLFSSL_DH_EXTRA -DWOLFSSL_PSS_SALT_LEN_DISCOVER -DWOLFSSL_PUBLIC_MP -DWOLFSSL_RSA_KEY_CHECK' --enable-fips=v5
 
     make
 
@@ -89,7 +89,7 @@ else
     cd ./wolfssl
     ./autogen.sh
 
-    ./configure --prefix=$WOLFSSL_INSTALL/ CC=clang --enable-cmac --enable-ed25519 --enable-ed448 --enable-curve25519 --enable-curve448 --enable-aesccm --enable-aesxts --enable-aescfb --enable-keygen --enable-shake128 --enable-shake256 'CFLAGS=-DWOLFSSL_PUBLIC_ASN -DHAVE_FFDHE_3072 -DHAVE_FFDHE_4096 -DWOLFSSL_DH_EXTRA -DWOLFSSL_PSS_SALT_LEN_DISCOVER -DWOLFSSL_PUBLIC_MP'
+    ./configure --prefix=$WOLFSSL_INSTALL/ CC=clang --enable-cmac --enable-ed25519 --enable-ed448 --enable-curve25519 --enable-curve448 --enable-aesccm --enable-aesxts --enable-aescfb --enable-keygen --enable-shake128 --enable-shake256 'CFLAGS=-DWOLFSSL_PUBLIC_ASN -DHAVE_FFDHE_3072 -DHAVE_FFDHE_4096 -DWOLFSSL_DH_EXTRA -DWOLFSSL_PSS_SALT_LEN_DISCOVER -DWOLFSSL_PUBLIC_MP -DWOLFSSL_RSA_KEY_CHECK'
 
     make
     sudo make install


### PR DESCRIPTION
Check RSA private key on import.
Set curve properly on import.
Only try the detected algorithm when importing publc key. Make public key from private for Ed25519/Ed448/X25519/X448 when exporting public and not set.
Set RSA_PRIVATE into wolfSSL RSA key when raw d is imported. Make sure y is empty for exporting raw Ed25519/Ed448/X25519/X448.

Enable RSA check function in wolfSSL.