### PR TITLE
PK fixes

### DIFF
--- a/wolfssl-gnutls-wrapper/src/gnutls_compat.h
+++ b/wolfssl-gnutls-wrapper/src/gnutls_compat.h
@@ -512,3 +512,4 @@ int gnutls_crypto_single_pk_register(gnutls_pk_algorithm_t algorithm,
                                     const gnutls_crypto_pk_st *s,
                                     int free_s);
 
+extern int _gnutls_config_is_rsa_pkcs1_encrypt_allowed(void);


### PR DESCRIPTION
_gnutls_config_is_rsa_pkcs1_encrypt_allowed is needed for a GnuTLS test. Assume the key data is raw Ed25519 or Ed448 if no algorithm given and unable to parse DER and data is the right size.
Return into any non-NULL parameter when exporting raw EC. Also set y to NULL data and 0 size if no y-ordinate to return.