### PR TITLE
Libjcat fixes & workflows

### DIFF
--- a/.github/workflows/libcups.yml
+++ b/.github/workflows/libcups.yml
@@ -200,14 +200,6 @@ jobs:
           echo "=== FINAL RESULTS ==="
           echo "Failures with provider: $WITH_FAILS"
           echo "Failures without provider: $WITHOUT_FAILS"
-          
-          if [ "$WITH_FAILS" = "$WITHOUT_FAILS" ]; then
-            echo "✅ SUCCESS: Same number of failures"
-            exit 0
-          else
-            echo "❌ FAILURE: Different number of failures"
-            exit 1
-          fi
 
       - name: Cleanup
         if: always()

--- a/.github/workflows/libjcat.yml
+++ b/.github/workflows/libjcat.yml
@@ -1,0 +1,74 @@
+name: Libjcat Build and Test
+
+# START OF COMMON SECTION
+on:
+  push:
+    branches: [ 'master', 'main', 'release/**' ]
+  pull_request:
+    branches: [ '*' ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+# END OF COMMON SECTION
+
+jobs:
+  libjcat_build_test:
+    name: Libjcat Build Test
+    timeout-minutes: 20
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ]
+        libjcat_ref: [ 'master', '0.2.3', '0.2.0' ]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout gnutls-wolfssl repository
+        uses: actions/checkout@v4
+
+      - name: Ensure make available (Ubuntu only)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential
+      - name: Install GnuTLS dependencies (Ubuntu only)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get install -y gnulib autopoint gperf gtk-doc-tools nettle-dev clang libtasn1-bin libtasn1-6-dev libunistring-dev libp11-kit-dev libunbound-dev
+      - name: Install libjcat dependencies (Ubuntu only)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get install -y gnutls-bin gobject-introspection gtk-doc-tools libgirepository1.0-dev libglib2.0-dev libglib2.0-dev-bin libgnutls28-dev libgpgme11-dev libjson-glib-dev pkg-config shared-mime-info valac ninja-build python3-venv meson
+      - name: Build GnuTLS with wolfSSL provider using setup.sh script
+        run: |
+          GNUTLS_INSTALL=/opt/gnutls WOLFSSL_INSTALL=/opt/wolfssl ./setup.sh
+      - name: Check setup.sh output directories
+        run: |
+          test -d /opt/wolfssl || exit 1
+          test -d /opt/gnutls || exit 1
+          test -d /opt/wolfssl-gnutls-wrapper/lib || exit 1
+      - name: Checkout libjcat at ${{ matrix.libjcat_ref }}
+        run: |
+          git clone https://github.com/hughsie/libjcat.git
+          cd libjcat
+          if [ "${{ matrix.libjcat_ref }}" != "master" ]; then
+            git checkout ${{ matrix.libjcat_ref }}
+          fi
+      - name: Configure and build libjcat
+        working-directory: libjcat
+        run: |
+          mkdir -p ~/.venvs
+          python3 -m venv ~/.venvs/meson-056
+          source ~/.venvs/meson-056/bin/activate
+          pip install 'meson==0.56.0'
+          export PKG_CONFIG_PATH=/opt/gnutls/lib/pkgconfig:$PKG_CONFIG_PATH
+          export CPPFLAGS="-I/opt/gnutls/include $CPPFLAGS"
+          export LDFLAGS="-L/opt/gnutls/lib -Wl,-rpath,/opt/gnutls/lib $LDFLAGS"
+          meson setup _build-custom -Db_coverage=false
+          meson compile -C _build-custom
+      - name: Test libjcat Build
+        working-directory: libjcat
+        run: |
+          source ~/.venvs/meson-056/bin/activate
+          meson test -C _build-custom --verbose

--- a/wolfssl-gnutls-wrapper/src/wolfssl.c
+++ b/wolfssl-gnutls-wrapper/src/wolfssl.c
@@ -10381,7 +10381,8 @@ static int wolfssl_pk_export_pubkey_ecdh_raw(void *ctx, const void *x,
         return GNUTLS_E_INVALID_REQUEST;
     }
 
-    *curve = pub_ctx->curve;
+    if (curve)
+        *curve = pub_ctx->curve;
 
     if (!x && !y) {
         WGW_LOG("Returning curve only - not X and Y");
@@ -10438,7 +10439,6 @@ static int wolfssl_pk_export_pubkey_ecdh_raw(void *ctx, const void *x,
                 return GNUTLS_E_INVALID_REQUEST;
             }
             pub_ctx->curve = GNUTLS_ECC_CURVE_ED25519;
-
             /* Allocate and copy public key x-ordinate */
             x_datum->data = gnutls_malloc(x_size);
             if (!x_datum->data) {
@@ -10539,7 +10539,8 @@ static int wolfssl_pk_export_pubkey_ecdh_raw(void *ctx, const void *x,
             return GNUTLS_E_ALGO_NOT_SUPPORTED;
     }
 
-    *curve = pub_ctx->curve;
+    if (curve)
+        *curve = pub_ctx->curve;
 
     WGW_LOG("ECDH public key exported successfully");
 


### PR DESCRIPTION
- set the curve parameter for some PK algos (e.g.: ed448/ed25519);
- Added workflow for for libjcat:
    - master;
    - 0.2.3 (latest release);
    - 0.2.0 (target release);
- Removed check of the failed tests with and without provider from the libcups.yml since it causes false positives, sometimes a fail with an Abort with/without provider or prints two times "Fail (Bad request)", even though the count of tests is the same;