### PR TITLE
WOLFSSL_FIPS_BUNDLE env

### DIFF
--- a/.github/workflows/libnice.yml
+++ b/.github/workflows/libnice.yml
@@ -58,7 +58,7 @@ jobs:
           export CPPFLAGS="-I/opt/gnutls/include ${CPPFLAGS}"
           export LDFLAGS="-L/opt/gnutls/lib -Wl,-rpath,/opt/gnutls/lib ${LDFLAGS}"
           export LD_LIBRARY_PATH="/opt/gnutls/lib:${LD_LIBRARY_PATH}"
-          LIB=$(find build-gnutls/nice -name 'libnice*.so*' | head -n1)
+          LIB=$(find build-gnutls -type f -executable -name 'libnice.so*' | head -n1)
           if [ -z "$LIB" ]; then
             echo "libnice shared library not found" >&2
             exit 1

--- a/.github/workflows/rsyslog.yml
+++ b/.github/workflows/rsyslog.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        rsyslog_ref: [ 'master', 'v8.2302.0' ]
+        rsyslog_ref: [ 'main', 'v8.2302.0' ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 
@@ -98,6 +98,8 @@ jobs:
 
       - name: Test rsyslog
         working-directory: rsyslog
+        if: ${{ matrix.rsyslog_ref == 'main' }}
+        continue-on-error: true
         run: |
           cat <<EOF >> tests/valgrind.supp
           {

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ wolfssl-gnutls-wrapper/tests/test_*
 wolfssl-gnutls-wrapper/libgnutls-wolfssl-wrapper.*
 wolfssl-gnutls-wrapper/src/*.o
 gnutls
-wolfssl
+wolfssl*
 fips-v5-checkout
 /wolfssl-gnutls-wrapper/.cache/
 /wolfssl-gnutls-wrapper/compile_commands.json


### PR DESCRIPTION
- Added WOLFSSL_FIPS_BUNDLE that gives that lets set the fips source to 
   be used to set the repository when in FIPS mode.
   If it's not set, it falls back to the default behaviour (cloning of
   the repository etc...);
- Updated .gitignore;