### PR TITLE
Misc. improvements to the debian package installation and general installation scripts.

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 
@@ -26,14 +26,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y clang bear
-
-      - name: Install clang + bear (macOS)
-        if: matrix.os == 'macos-latest'
-        run: |
-          brew update
-          brew install llvm bear
-          echo "$(brew --prefix llvm)/bin" >> $GITHUB_PATH
-          echo "SDKROOT=$(xcrun --show-sdk-path)" >> $GITHUB_ENV
 
       - name: Install dependencies (Ubuntu only)
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -24,17 +24,30 @@ jobs:
             build-essential devscripts debhelper-compat fakeroot clang \
             autoconf automake libtool pkg-config gettext bison flex gperf \
             libgmp-dev libunistring-dev nettle-dev libtasn1-dev libp11-kit-dev \
-            libev-dev gtk-doc-tools lintian libtasn1-bin
+            libev-dev gtk-doc-tools lintian libtasn1-bin git texinfo
 
-      - name: Build .deb set (non-FIPS)
+      - name: Build & install wolfSSL (non-FIPS)
+        run: |
+          set -e
+          git clone --depth=1 https://github.com/wolfssl/wolfssl.git
+          cd wolfssl
+          ./autogen.sh
+          ./configure CC=clang \
+            --enable-cmac --with-eccminsz=192 --enable-ed25519 --enable-ed448 --enable-md5 \
+            --enable-curve25519 --enable-curve448 \
+            --enable-aesccm --enable-aesxts --enable-aescfb \
+            --enable-keygen --enable-shake128 --enable-shake256 \
+            'CFLAGS=-DWOLFSSL_PUBLIC_ASN -DHAVE_FFDHE_3072 -DHAVE_FFDHE_4096 -DWOLFSSL_DH_EXTRA -DWOLFSSL_PSS_SALT_LEN_DISCOVER -DWOLFSSL_PUBLIC_MP -DWOLFSSL_RSA_KEY_CHECK -DHAVE_FFDHE_Q -DHAVE_FFDHE_6144 -DHAVE_FFDHE_8192 -DWOLFSSL_ECDSA_DETERMINISTIC_K -DWOLFSSL_VALIDATE_ECC_IMPORT -DRSA_MIN_SIZE=1024'
+          make -j"$(nproc)"
+          sudo make deb
+          sudo dpkg -i libwolfssl_*.deb libwolfssl-dev_*.deb
+
+      - name: Build .deb set (gnutls-wolfssl non-FIPS)
         run: dpkg-buildpackage -us -uc -b
 
-      - name: Install built packages
+      - name: Install built packages (needed for the smoke test)
         run: |
-          sudo dpkg -i ../wolfssl-custom_*_amd64.deb \
-                      ../gnutls-wolfssl_*_amd64.deb  \
-                      ../wolfssl-gnutls-wrapper_*_amd64.deb
-          sudo ldconfig
+          sudo dpkg -i ../gnutls-wolfssl_*.deb ../wolfssl-gnutls-wrapper_*.deb || sudo apt-get -f install -y
 
       - name: Wrapper-load smoke test
         run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest ]
         provider:
           - ""
           - "GNUTLS_NO_PROVIDER=1"

--- a/debian/README.debian
+++ b/debian/README.debian
@@ -1,7 +1,6 @@
 gnutls-wolfssl for Debian
 
 This source package builds three binary packages:
-	•	wolfssl-custom               – wolfSSL with the custom options required by GnuTLS
 	•	gnutls-wolfssl               – GnuTLS built to use wolfSSL as its crypto backend
 	•	wolfssl-gnutls-wrapper       – Runtime provider that links GnuTLS and wolfSSL,
                                        effectively backend that takes care of the
@@ -32,13 +31,18 @@ dpkg-buildpackage -us -uc -b
 Build FIPS flavour:
 
 ```
-dpkg-buildpackage -us -uc -b -Pfips     # or  FIPS=1 dpkg-buildpackage -us -uc -b
+dpkg-buildpackage -us -uc -b -Pfips
+```
+
+or
+
+```
+FIPS=1 dpkg-buildpackage -us -uc -b
 ```
 
 3.	The .deb artefacts appear in the parent directory:
 
 ```
-../wolfssl-custom_amd64.deb
 ../gnutls-wolfsslamd64.deb
 ../wolfssl-gnutls-wrapper_amd64.deb
 ```
@@ -90,3 +94,4 @@ For project details see:
 https://github.com/wolfSSL/gnutls-wolfssl
 
 – wolfSSL support@wolfssl.com
+

--- a/debian/control
+++ b/debian/control
@@ -22,30 +22,23 @@ Build-Depends:
  libtasn1-bin,
  libev-dev,
  texinfo,
- gtk-doc-tools
+ gtk-doc-tools,
+ libwolfssl
 Standards-Version: 4.6.2
 Homepage: https://github.com/wolfssl/gnutls-wolfssl
 Rules-Requires-Root: no
 
-Package: wolfssl-custom
+Package: gnutls-wolfssl
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Section: libs
-Description: wolfSSL TLS library (custom build, /opt prefix)
- wolfSSL compiled with the extended algorithm set required by the
- gnutls-wolfssl experiment.  Installs under /opt/wolfssl.
-
-Package: gnutls-wolfssl
-Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, wolfssl-custom (>= ${binary:Version})
-Section: libs
 Description: GnuTLS linked against wolfSSL (/opt prefix)
  GnuTLS 3.x rebuilt to use wolfSSL as its cryptographic backend.
- Installs under /opt/gnutls.
+ Installs under /opt/gnutls (To prevent conflicts).
 
 Package: wolfssl-gnutls-wrapper
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, wolfssl-custom, gnutls-wolfssl
+Depends: ${shlibs:Depends}, ${misc:Depends}, gnutls-wolfssl, libwolfssl
 Section: libs
 Description: Runtime shim between GnuTLS and wolfSSL
  Thin provider / wrapper that allows applications to load the

--- a/debian/rules
+++ b/debian/rules
@@ -24,11 +24,10 @@ override_dh_auto_build:
 	:
 
 override_dh_auto_install:
-	-sudo rm -rf /opt/wolfssl /opt/gnutls /opt/wolfssl-gnutls-wrapper
+	-sudo rm -rf /opt/gnutls /opt/wolfssl-gnutls-wrapper
 
 	./setup.sh $(FIPS_ARG)
 
 	mkdir -p $(CURDIR)/debian/tmp/opt
-	cp -a /opt/wolfssl                $(CURDIR)/debian/tmp/opt/
 	cp -a /opt/gnutls                 $(CURDIR)/debian/tmp/opt/
 	cp -a /opt/wolfssl-gnutls-wrapper $(CURDIR)/debian/tmp/opt/

--- a/debian/shlibs.local
+++ b/debian/shlibs.local
@@ -1,0 +1,1 @@
+libwolfssl 44 libwolfssl

--- a/debian/wolfssl-custom.install
+++ b/debian/wolfssl-custom.install
@@ -1,1 +1,0 @@
-opt/wolfssl/*

--- a/debian/wolfssl-custom.lintian-overrides
+++ b/debian/wolfssl-custom.lintian-overrides
@@ -1,2 +1,0 @@
-dir-or-file-in-opt
-binary-or-shlib-defines-rpath

--- a/wolfssl-gnutls-wrapper/Makefile
+++ b/wolfssl-gnutls-wrapper/Makefile
@@ -1,5 +1,40 @@
-CC = gcc
-INCLUDES = -I/opt/gnutls/include/ -I/opt/wolfssl/include/
+PKGCONF ?= pkg-config
+CC ?= gcc
+
+# Prefixes used when pkg-config isn't available
+GNUTLS_PREFIX := $(if $(GNUTLS_INSTALL),$(GNUTLS_INSTALL),/opt/gnutls)
+WOLFSSL_PREFIX := $(if $(WOLFSSL_INSTALL),$(WOLFSSL_INSTALL),/opt/wolfssl)
+
+# Make sure pkg-config can see a custom /opt gnutls, if present
+export PKG_CONFIG_PATH := $(GNUTLS_PREFIX)/lib/pkgconfig:$(PKG_CONFIG_PATH)
+
+# Detect availability of pkg-config .pc files
+HAVE_PC_WOLFSSL := $(shell $(PKGCONF) --exists wolfssl && echo yes || echo no)
+HAVE_PC_GNUTLS  := $(shell $(PKGCONF) --exists gnutls  && echo yes || echo no)
+
+# Flags from pkg-config (prefer), otherwise fall back to /opt/* paths
+ifeq ($(HAVE_PC_WOLFSSL),yes)
+  WOLFSSL_CFLAGS := $(shell $(PKGCONF) --cflags wolfssl)
+  WOLFSSL_LIBS   := $(shell $(PKGCONF) --libs   wolfssl)
+  WOLFSSL_LIBDIR := $(shell $(PKGCONF) --variable=libdir wolfssl)
+else
+  WOLFSSL_CFLAGS := -I$(WOLFSSL_PREFIX)/include
+  WOLFSSL_LIBS   := -L$(WOLFSSL_PREFIX)/lib -lwolfssl
+  WOLFSSL_LIBDIR := $(WOLFSSL_PREFIX)/lib
+endif
+
+ifeq ($(HAVE_PC_GNUTLS),yes)
+  GNUTLS_CFLAGS := $(shell $(PKGCONF) --cflags gnutls)
+  GNUTLS_LIBS   := $(shell $(PKGCONF) --libs   gnutls)
+  GNUTLS_LIBDIR := $(shell $(PKGCONF) --variable=libdir gnutls)
+else
+  GNUTLS_CFLAGS := -I$(GNUTLS_PREFIX)/include
+  GNUTLS_LIBS   := -L$(GNUTLS_PREFIX)/lib -lgnutls
+  GNUTLS_LIBDIR := $(GNUTLS_PREFIX)/lib
+endif
+
+# Include dirs (now come from pkg-config when available)
+INCLUDES := $(GNUTLS_CFLAGS) $(WOLFSSL_CFLAGS)
 
 # Default to /opt/wolfssl-gnutls-wrapper when the user hasn’t supplied PROVIDER_PATH
 ifndef PROVIDER_PATH
@@ -9,31 +44,35 @@ endif
 UNAME_S := $(shell uname -s)
 
 ifeq ($(UNAME_S),Linux)
-	CFLAGS       = -DENABLE_WOLFSSL -fPIC -Wall -Wextra -Werror
-	CFLAGS_DEBUG = -DENABLE_WOLFSSL -fPIC -Wall -Wextra -Werror -g
-	LDFLAGS      = -shared -L/opt/gnutls/lib -L/opt/wolfssl/lib \
-	              -Wl,-rpath,/opt/wolfssl/lib -Wl,--no-as-needed -Wl,-z,now
+  CFLAGS       += -DENABLE_WOLFSSL -fPIC -Wall -Wextra
+  CFLAGS_DEBUG += -g
+  # Use rpath to wherever we actually link from
+  LDFLAGS      += -Wl,--no-as-needed -Wl,-z,now \
+                  -Wl,-rpath,$(GNUTLS_LIBDIR) -Wl,-rpath,$(WOLFSSL_LIBDIR)
+  SOFLAG := -shared
+  DL_LIBS := -ldl
 endif
 
 ifeq ($(UNAME_S),Darwin)
-	CC           = clang
-	CFLAGS       = -DENABLE_WOLFSSL -fPIC -Wall -Wextra
-	CFLAGS_DEBUG = -DENABLE_WOLFSSL -fPIC -Wall -Wextra -g
-	LDFLAGS      = -shared -L/opt/gnutls/lib -L/opt/wolfssl/lib \
-	              -Wl,-rpath,/opt/wolfssl/lib
+  CC           := clang
+  CFLAGS       += -DENABLE_WOLFSSL -fPIC -Wall -Wextra
+  CFLAGS_DEBUG += -g
+  LDFLAGS      += -Wl,-rpath,$(GNUTLS_LIBDIR) -Wl,-rpath,$(WOLFSSL_LIBDIR)
+  SOFLAG := -dynamiclib
+  DL_LIBS :=
 endif
 
-LIBS = -lgnutls -lwolfssl -ldl
+# Link libs: prefer pkg-config expansion; fallback already includes -l flags
+LIBS := $(GNUTLS_LIBS) $(WOLFSSL_LIBS) $(DL_LIBS)
 
 WRAPPER_TARGET := libgnutls-wolfssl-wrapper.so
-
 WRAPPER_SRCS   := $(wildcard src/*.c)
 WRAPPER_OBJS   := $(WRAPPER_SRCS:.c=.o)
 
 all: $(WRAPPER_TARGET)
 
 $(WRAPPER_TARGET): $(WRAPPER_OBJS)
-	$(CC) $(LDFLAGS) -o $@ $(WRAPPER_OBJS) $(LIBS)
+	$(CC) $(SOFLAG) $(LDFLAGS) -o $@ $(WRAPPER_OBJS) $(LIBS)
 
 %.o: %.c
 	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@

--- a/wolfssl-gnutls-wrapper/tests/Makefile
+++ b/wolfssl-gnutls-wrapper/tests/Makefile
@@ -1,25 +1,57 @@
 TESTS = test_hash test_long_hash test_shake test_aescbc test_aescfb8 test_aesgcm test_aesccm test_aesxts test_hmac test_cmac test_gmac test_rnd test_rnd_fork test_tls_prf test_hkdf test_pbkdf2 test_ecdsa_sign_and_verify test_ecdh_encrypt_and_decrypt test_eddsa_sign_and_verify test_rsa_sign_and_verify test_rsa_encrypt_and_decrypt test_dh_encrypt_and_decrypt test_pk_import_export test_long_hash test_fips
 
-UNAME_S := $(shell uname -s)
-INCLUDES = -I/opt/gnutls/include/ -I/opt/gnutls/include/gnutls/
-
+PKGCONF ?= pkg-config
 UNAME_S := $(shell uname -s)
 
-ifeq ($(UNAME_S),Darwin)
-    CC = clang
+# Defaults; can be overridden by environment
+GNUTLS_PREFIX  := $(if $(GNUTLS_INSTALL),$(GNUTLS_INSTALL),/opt/gnutls)
+PROVIDER_PATH  := $(if $(PROVIDER_PATH),$(PROVIDER_PATH),/opt/wolfssl-gnutls-wrapper)
+
+# Make pkg-config see a custom /opt gnutls, if present
+export PKG_CONFIG_PATH := $(GNUTLS_PREFIX)/lib/pkgconfig:$(PKG_CONFIG_PATH)
+
+# Detect pkg-config availability of gnutls
+HAVE_PC_GNUTLS := $(shell $(PKGCONF) --exists gnutls && echo yes || echo no)
+
+ifeq ($(HAVE_PC_GNUTLS),yes)
+  GNUTLS_CFLAGS := $(shell $(PKGCONF) --cflags gnutls)
+  GNUTLS_LIBS   := $(shell $(PKGCONF) --libs   gnutls)
+  GNUTLS_LIBDIR := $(shell $(PKGCONF) --variable=libdir gnutls)
 else
-    CC = gcc
+  GNUTLS_CFLAGS := -I$(GNUTLS_PREFIX)/include -I$(GNUTLS_PREFIX)/include/gnutls
+  GNUTLS_LIBS   := -L$(GNUTLS_PREFIX)/lib -lgnutls
+  GNUTLS_LIBDIR := $(GNUTLS_PREFIX)/lib
 endif
 
-ifeq ($(UNAME_S),Linux)
-    LDFLAGS = -L/opt/gnutls/lib -Wl,-rpath,/opt/gnutls/lib -Wl,--no-as-needed -Wl,-z,now
-endif
+PROVIDER_LIBDIR := $(PROVIDER_PATH)/lib
 
+# Compiler
 ifeq ($(UNAME_S),Darwin)
-    LDFLAGS = -L/opt/gnutls/lib -Wl,-rpath,/opt/gnutls/lib
+  CC = clang
+else
+  CC = gcc
 endif
 
-LIBS = -lgnutls -ldl
+# Includes
+INCLUDES = $(GNUTLS_CFLAGS)
+
+# Linker flags + rpaths to BOTH gnutls and provider
+ifeq ($(UNAME_S),Linux)
+  LDFLAGS = -Wl,--no-as-needed -Wl,-z,now \
+            -Wl,-rpath,$(GNUTLS_LIBDIR) -Wl,-rpath,$(PROVIDER_LIBDIR) \
+            -L$(GNUTLS_LIBDIR)
+endif
+ifeq ($(UNAME_S),Darwin)
+  LDFLAGS = -Wl,-rpath,$(GNUTLS_LIBDIR) -Wl,-rpath,$(PROVIDER_LIBDIR) \
+            -L$(GNUTLS_LIBDIR)
+endif
+
+# Libraries (dl only on Linux)
+ifeq ($(UNAME_S),Linux)
+  LIBS = $(GNUTLS_LIBS) -ldl
+else
+  LIBS = $(GNUTLS_LIBS)
+endif
 
 all: $(TESTS)
 
@@ -27,13 +59,13 @@ all: $(TESTS)
 	$(CC) -g -o $@ $< $(INCLUDES) $(LDFLAGS) $(LIBS)
 
 run-%:
-	GNUTLS_DEBUG_LEVEL=9 ./$*
+	GNUTLS_DEBUG_LEVEL=9 LD_LIBRARY_PATH="$(GNUTLS_LIBDIR):$(PROVIDER_LIBDIR):$$LD_LIBRARY_PATH" DYLD_LIBRARY_PATH="$(GNUTLS_LIBDIR):$(PROVIDER_LIBDIR):$$DYLD_LIBRARY_PATH" ./$*
 
 run: $(TESTS)
 	@passed=0; failed=0; failed_tests=""; \
 	for test in $(TESTS); do \
 		echo "\n>> Running $$test..."; \
-		if GNUTLS_DEBUG_LEVEL=9 $(VALGRIND) ./$$test $(CMD_LINE_ARG); then \
+		if GNUTLS_DEBUG_LEVEL=9 LD_LIBRARY_PATH="$(GNUTLS_LIBDIR):$(PROVIDER_LIBDIR):$$LD_LIBRARY_PATH" DYLD_LIBRARY_PATH="$(GNUTLS_LIBDIR):$(PROVIDER_LIBDIR):$$DYLD_LIBRARY_PATH" $(VALGRIND) ./$$test $(CMD_LINE_ARG); then \
 			echo "\n✅ $$test PASSED"; \
 			passed=$$((passed+1)); \
 		else \
@@ -54,25 +86,25 @@ run: $(TESTS)
 	fi
 
 run_fast:
-	CMD_LINE_ARG="-fast" make run
+	CMD_LINE_ARG="-fast" $(MAKE) run
 
 run_valgrind:
-	VALGRIND=valgrind  make run_fast
+	VALGRIND=valgrind $(MAKE) run_fast
 
 run_fips: $(TESTS)
-	GNUTLS_FORCE_FIPS_MODE=1 make run
+	GNUTLS_FORCE_FIPS_MODE=1 $(MAKE) run
 
 run_gnutls: $(TESTS)
-	GNUTLS_NO_PROVIDER=1 make run
+	GNUTLS_NO_PROVIDER=1 $(MAKE) run
 
 run_fast_gnutls: $(TESTS)
-	GNUTLS_NO_PROVIDER=1 make run_fast
+	GNUTLS_NO_PROVIDER=1 $(MAKE) run_fast
 
 run_valgrind_gnutls: $(TESTS)
-	GNUTLS_NO_PROVIDER=1 make run_valgrind
+	GNUTLS_NO_PROVIDER=1 $(MAKE) run_valgrind
 
 clean:
 	rm -f $(TESTS)
 	rm -rf *.dSYM
 
-.PHONY += run run-verbose
+.PHONY += all run run-% run_fast run_valgrind run_fips run_gnutls run_fast_gnutls run_valgrind_gnutls clean

--- a/wolfssl-gnutls-wrapper/tests/test_tls_prf.c
+++ b/wolfssl-gnutls-wrapper/tests/test_tls_prf.c
@@ -91,9 +91,10 @@ static int test_tls_prf(gnutls_mac_algorithm_t mac_alg,
 
 int main(void)
 {
-    int ret;
+    int ret = 0;
     unsigned char buf[256];
     unsigned char output[64];
+    int fips_mode;
 
     memset(buf, 0xa5, sizeof(buf));
 
@@ -104,8 +105,12 @@ int main(void)
         return 1;
     }
 
-    ret = test_tls_prf(GNUTLS_MAC_MD5_SHA1, expected_md5_sha1,
-        sizeof(expected_md5_sha1));
+    /* Check if FIPS mode is enabled */
+    fips_mode = gnutls_fips140_mode_enabled();
+    if (fips_mode == 0) {
+        ret = test_tls_prf(GNUTLS_MAC_MD5_SHA1, expected_md5_sha1,
+                sizeof(expected_md5_sha1));
+    }
     if (ret == 0) {
         ret = test_tls_prf(GNUTLS_MAC_SHA256, expected_sha256,
             sizeof(expected_sha256));


### PR DESCRIPTION
- Switch to system wolfSSL: drop wolfssl-custom, auto-detect via pkg-config in setup.sh, update Debian/CI, and make wrapper/tests use pkg-config with correct rpaths. Package only /opt/gnutls and /opt/wolfssl-gnutls-wrapper;
- Removed macos workflows;
- Disabled md5 when enabling FIPS mode;