### PR TITLE
Removed gnutls global installation detection (fallback to GNUTLS_INSTALL, /opt/gnutls otherwise)

### DIFF
--- a/wolfssl-gnutls-wrapper/Makefile
+++ b/wolfssl-gnutls-wrapper/Makefile
@@ -5,12 +5,13 @@ CC ?= gcc
 GNUTLS_PREFIX := $(if $(GNUTLS_INSTALL),$(GNUTLS_INSTALL),/opt/gnutls)
 WOLFSSL_PREFIX := $(if $(WOLFSSL_INSTALL),$(WOLFSSL_INSTALL),/opt/wolfssl)
 
-# Make sure pkg-config can see a custom /opt gnutls, if present
-export PKG_CONFIG_PATH := $(GNUTLS_PREFIX)/lib/pkgconfig:$(PKG_CONFIG_PATH)
+# Use a dedicated pkg-config path ONLY for GnuTLS detection (no global lookup)
+GNUTLS_PKGCONF := PKG_CONFIG_PATH=$(GNUTLS_PREFIX)/lib/pkgconfig $(PKGCONF)
 
 # Detect availability of pkg-config .pc files
 HAVE_PC_WOLFSSL := $(shell $(PKGCONF) --exists wolfssl && echo yes || echo no)
-HAVE_PC_GNUTLS  := $(shell $(PKGCONF) --exists gnutls  && echo yes || echo no)
+# Only check under GNUTLS_PREFIX; do NOT use global gnutls
+HAVE_PC_GNUTLS  := $(shell $(GNUTLS_PKGCONF) --exists gnutls && echo yes || echo no)
 
 # Flags from pkg-config (prefer), otherwise fall back to /opt/* paths
 ifeq ($(HAVE_PC_WOLFSSL),yes)
@@ -24,9 +25,9 @@ else
 endif
 
 ifeq ($(HAVE_PC_GNUTLS),yes)
-  GNUTLS_CFLAGS := $(shell $(PKGCONF) --cflags gnutls)
-  GNUTLS_LIBS   := $(shell $(PKGCONF) --libs   gnutls)
-  GNUTLS_LIBDIR := $(shell $(PKGCONF) --variable=libdir gnutls)
+  GNUTLS_CFLAGS := $(shell $(GNUTLS_PKGCONF) --cflags gnutls)
+  GNUTLS_LIBS   := $(shell $(GNUTLS_PKGCONF) --libs   gnutls)
+  GNUTLS_LIBDIR := $(shell $(GNUTLS_PKGCONF) --variable=libdir gnutls)
 else
   GNUTLS_CFLAGS := -I$(GNUTLS_PREFIX)/include
   GNUTLS_LIBS   := -L$(GNUTLS_PREFIX)/lib -lgnutls

--- a/wolfssl-gnutls-wrapper/tests/Makefile
+++ b/wolfssl-gnutls-wrapper/tests/Makefile
@@ -7,16 +7,17 @@ UNAME_S := $(shell uname -s)
 GNUTLS_PREFIX  := $(if $(GNUTLS_INSTALL),$(GNUTLS_INSTALL),/opt/gnutls)
 PROVIDER_PATH  := $(if $(PROVIDER_PATH),$(PROVIDER_PATH),/opt/wolfssl-gnutls-wrapper)
 
-# Make pkg-config see a custom /opt gnutls, if present
-export PKG_CONFIG_PATH := $(GNUTLS_PREFIX)/lib/pkgconfig:$(PKG_CONFIG_PATH)
+# Use a *scoped* pkg-config for GnuTLS only (no global fallback).
+# PKG_CONFIG_LIBDIR overrides default search dirs so we don't touch system /usr.
+GNUTLS_PKGCONF := PKG_CONFIG_LIBDIR=$(GNUTLS_PREFIX)/lib/pkgconfig $(PKGCONF)
 
-# Detect pkg-config availability of gnutls
-HAVE_PC_GNUTLS := $(shell $(PKGCONF) --exists gnutls && echo yes || echo no)
+# Detect pkg-config availability of gnutls (ONLY under GNUTLS_PREFIX)
+HAVE_PC_GNUTLS := $(shell $(GNUTLS_PKGCONF) --exists gnutls && echo yes || echo no)
 
 ifeq ($(HAVE_PC_GNUTLS),yes)
-  GNUTLS_CFLAGS := $(shell $(PKGCONF) --cflags gnutls)
-  GNUTLS_LIBS   := $(shell $(PKGCONF) --libs   gnutls)
-  GNUTLS_LIBDIR := $(shell $(PKGCONF) --variable=libdir gnutls)
+  GNUTLS_CFLAGS := $(shell $(GNUTLS_PKGCONF) --cflags gnutls)
+  GNUTLS_LIBS   := $(shell $(GNUTLS_PKGCONF) --libs   gnutls)
+  GNUTLS_LIBDIR := $(shell $(GNUTLS_PKGCONF) --variable=libdir gnutls)
 else
   GNUTLS_CFLAGS := -I$(GNUTLS_PREFIX)/include -I$(GNUTLS_PREFIX)/include/gnutls
   GNUTLS_LIBS   := -L$(GNUTLS_PREFIX)/lib -lgnutls


### PR DESCRIPTION
- If GNUTLS_INSTALL is not set, look into /opt/gnutls;
- Kept existing logic for wolfSSL (if not globally installed -> Look into /opt/wolfssl or WOLFSSL_INSTALL If set)