### PR TITLE
Migrating from ubuntu to debian:bookworm

### DIFF
--- a/.github/workflows/chrony.yml
+++ b/.github/workflows/chrony.yml
@@ -22,6 +22,8 @@ jobs:
         chrony_ref: [ 'master', '4.3', '4.6.1' ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    container:
+      image: debian:bookworm
 
     steps:
       - name: Checkout gnutls-wolfssl repository
@@ -30,13 +32,13 @@ jobs:
       - name: Ensure make available (Ubuntu only)
         if: matrix.os == 'ubuntu-latest'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential
+          apt-get update
+          apt-get install -y build-essential
 
       - name: Install GnuTLS dependencies (Ubuntu only)
         if: matrix.os == 'ubuntu-latest'
         run: |
-          sudo apt-get install -y gnulib autopoint gperf gtk-doc-tools nettle-dev clang libtasn1-bin libtasn1-6-dev libunistring-dev libp11-kit-dev libunbound-dev
+          apt-get install -y gnulib autopoint gperf gtk-doc-tools nettle-dev clang libtasn1-bin libtasn1-6-dev libunistring-dev libp11-kit-dev libunbound-dev sudo wget git
 
       - name: Install chrony dependencies (Ubuntu only)
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -16,6 +16,8 @@ jobs:
         os: [ ubuntu-latest ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    container:
+      image: debian:bookworm
 
     steps:
       - name: Checkout repository
@@ -24,15 +26,15 @@ jobs:
       - name: Install clang + bear (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y clang bear
+          apt-get update
+          apt-get install -y clang bear sudo wget git
 
       - name: Install dependencies (Ubuntu only)
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo apt-get install -y gnulib autopoint gperf gtk-doc-tools nettle-dev clang \
-            libtasn1-bin libtasn1-6-dev libunistring-dev libp11-kit-dev libunbound-dev
+            libtasn1-bin libtasn1-6-dev libunistring-dev libp11-kit-dev libunbound-dev clang-tidy
 
       # ─────────────── cache the wolfssl/gnutls tool-chain ────────────────
       - name: Restore cached gnutls-wolfssl
@@ -61,6 +63,6 @@ jobs:
 
       - name: Run clang-tidy
         run: |
-          FILES=$(git -C wolfssl-gnutls-wrapper ls-files src/*.c tests/*.c | sed 's|^|wolfssl-gnutls-wrapper/|')
+          FILES=$(find wolfssl-gnutls-wrapper/src wolfssl-gnutls-wrapper/tests -name "*.c" -type f)
           clang-tidy -p wolfssl-gnutls-wrapper $FILES
 

--- a/.github/workflows/curl.yml
+++ b/.github/workflows/curl.yml
@@ -22,6 +22,8 @@ jobs:
         curl_ref: [ 'master', 'curl-7_88_1', 'curl-8_4_0' ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    container:
+      image: debian:bookworm
 
     steps:
       - name: Checkout repository
@@ -30,19 +32,19 @@ jobs:
       - name: Ensure make available (Ubuntu only)
         if: matrix.os == 'ubuntu-latest'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential
+          apt-get update
+          apt-get install -y build-essential
 
       - name: Install GnuTLS dependencies (Ubuntu only)
         if: matrix.os == 'ubuntu-latest'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y gnulib autopoint gperf gtk-doc-tools nettle-dev clang libtasn1-bin libtasn1-6-dev libunistring-dev libp11-kit-dev libunbound-dev
+          apt-get update
+          apt-get install -y gnulib autopoint gperf gtk-doc-tools nettle-dev clang libtasn1-bin libtasn1-6-dev libunistring-dev libp11-kit-dev libunbound-dev sudo wget git
 
       - name: Install curl test dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install nghttp2 libpsl5 libpsl-dev python3-impacket
+          sudo apt-get install -y nghttp2 libpsl5 libpsl-dev python3-impacket
 
       - name: Restore cached gnutls-wolfssl
         id: cache-gnutls
@@ -96,4 +98,6 @@ jobs:
 
       - name: Test curl
         working-directory: curl
-        run: WGW_LOGGING=0 make -j $(nproc) test-ci
+        run: |
+          export USER=root
+          WGW_LOGGING=0 make -j $(nproc) test-ci

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -11,6 +11,8 @@ concurrency:
 jobs:
   deb-testing:
     runs-on: ubuntu-latest
+    container:
+      image: debian:bookworm
     env:
       DEBIAN_FRONTEND: noninteractive
     steps:
@@ -19,12 +21,13 @@ jobs:
 
       - name: Install build tooling
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
+          apt-get update
+          apt-get install -y --no-install-recommends \
             build-essential devscripts debhelper-compat fakeroot clang \
             autoconf automake libtool pkg-config gettext bison flex gperf \
             libgmp-dev libunistring-dev nettle-dev libtasn1-dev libp11-kit-dev \
-            libev-dev gtk-doc-tools lintian libtasn1-bin git texinfo
+            libev-dev gtk-doc-tools lintian libtasn1-bin git texinfo sudo git \
+            wget
 
       - name: Build & install wolfSSL (non-FIPS)
         run: |

--- a/.github/workflows/dirmngr.yml
+++ b/.github/workflows/dirmngr.yml
@@ -14,6 +14,8 @@ jobs:
   build_and_test:
     name: Build wolfSSL + GnuTLS, then GnuPG ${{ matrix.gnupg_ref }}
     runs-on: ubuntu-latest
+    container:
+      image: debian:bookworm
     timeout-minutes: 40
     strategy:
       matrix:
@@ -26,12 +28,12 @@ jobs:
 
       - name: Install build prerequisites
         run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential autoconf automake libtool \
+          apt-get update
+          apt-get install -y build-essential autoconf automake libtool \
                                   gettext texinfo pkg-config wget gnulib \
                                   autopoint gperf gtk-doc-tools nettle-dev \
                                   clang libtasn1-bin libtasn1-6-dev \
-                                  libunistring-dev libp11-kit-dev libunbound-dev
+                                  libunistring-dev libp11-kit-dev libunbound-dev sudo wget git
 
       - name: Restore cached wolfSSL/GnuTLS
         id: cache-gnutls

--- a/.github/workflows/fwupd.yml
+++ b/.github/workflows/fwupd.yml
@@ -22,6 +22,8 @@ jobs:
         fwupd_ref: [ 'main', '1.9.26', '2.0.12' ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    container:
+      image: debian:bookworm
 
     steps:
       - name: Checkout gnutls-wolfssl repository
@@ -30,8 +32,8 @@ jobs:
       - name: Ensure make available (Ubuntu only)
         if: matrix.os == 'ubuntu-latest'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential
+          apt-get update
+          apt-get install -y build-essential sudo wget git
 
       - name: Install GnuTLS dependencies (Ubuntu only)
         if: matrix.os == 'ubuntu-latest'
@@ -45,11 +47,16 @@ jobs:
           sudo apt install -y \
             meson ninja-build git libgusb-dev libglib2.0-dev libxmlb-dev \
             libsoup2.4-dev libarchive-dev libjson-glib-dev libpolkit-gobject-1-dev \
-            libsystemd-dev valgrind gobject-introspection gtk-doc-tools python3-pip \
+            libsystemd-dev valgrind gobject-introspection libgirepository1.0-dev gtk-doc-tools python3-pip \
             libgpgme-dev valac libcurl4-gnutls-dev libpango-1.0-0 libpangocairo-1.0-0 \
             libpango1.0-dev libcairo2 libcairo2-dev libcairo-gobject2 python3-cairo \
             python3-gi-cairo python3-gi gir1.2-pango-1.0 gir1.2-cairo-1.0 gir1.2-gtk-3.0 \
             gnu-efi flashrom libflashrom-dev mingw-w64-tools libumockdev-dev
+          sudo apt-get install -y python3-pip
+          sudo apt-get install -y policykit-1 libpolkit-agent-1-dev gettext itstool
+          sudo apt-get install -y libzstd-dev zstd
+          pip3 install --break-system-packages jinja2 packaging typogrify
+          pip3 install --break-system-packages --upgrade meson
 
       - name: Install build and test dependencies (Ubuntu only)
         if: matrix.os == 'ubuntu-latest'
@@ -89,6 +96,18 @@ jobs:
           git clone https://github.com/fwupd/fwupd.git
           cd fwupd
           git checkout ${{ matrix.fwupd_ref }}
+
+      - name: Patch fwupd tests for Debian Bookworm compatibility
+        if: matrix.fwupd_ref != '1.9.26'
+        working-directory: fwupd
+        run: |
+          # GLib in Debian Bookworm emits WARNING for invalid properties while
+          # Ubuntu's GLib emits CRITICAL. Same behavior, different log level.
+          # Adjust test expectations to match Debian's GLib.
+          # This gets applied only for the latest version and the latest main branch,
+          # target version remains untouched since it's using the correct older version
+          # of glib that matches the one on debian:bookworm.
+          sed -i 's/GLib-GObject-CRITICAL/GLib-GObject-WARNING/g' libfwupd/fwupd-self-test.c
 
       - name: Configure fwupd
         working-directory: fwupd

--- a/.github/workflows/glib-networking.yml
+++ b/.github/workflows/glib-networking.yml
@@ -22,6 +22,8 @@ jobs:
         glib-networking_ref: [ 'master', '2.74.0', '2.80.1' ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    container:
+      image: debian:bookworm
 
     steps:
       - name: Checkout gnutls-wolfssl repository
@@ -30,13 +32,13 @@ jobs:
       - name: Ensure make available (Ubuntu only)
         if: matrix.os == 'ubuntu-latest'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential
+          apt-get update
+          apt-get install -y build-essential
 
       - name: Install GnuTLS dependencies (Ubuntu only)
         if: matrix.os == 'ubuntu-latest'
         run: |
-          sudo apt-get install -y gnulib autopoint gperf gtk-doc-tools nettle-dev clang libtasn1-bin libtasn1-6-dev libunistring-dev libp11-kit-dev libunbound-dev
+          apt-get install -y gnulib autopoint gperf gtk-doc-tools nettle-dev clang libtasn1-bin libtasn1-6-dev libunistring-dev libp11-kit-dev libunbound-dev sudo wget git
 
       - name: Install glib-networking dependencies (Ubuntu only)
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/gst-libav1.0.yml
+++ b/.github/workflows/gst-libav1.0.yml
@@ -1,5 +1,4 @@
 name: gst-libav1.0 Build and Test
-
 on:
   push:
     branches: [ 'master', 'main', 'release/**' ]
@@ -8,30 +7,25 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
 jobs:
   build_and_test:
     name: Build & Test gst-libav1.0
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:25.04
+      image: debian:bookworm
       options: --user root
     timeout-minutes: 60
-
     strategy:
       matrix:
         gst_ref: [ 'master', 'debian/1.26.2-1', 'debian/1.26.3-1' ]
       fail-fast: false
-
     steps:
       - name: Checkout gnutls-wolfssl repository
         uses: actions/checkout@v4
-
       - name: Install Meson and ninja
         run: |
           apt-get update
           apt-get install -y sudo meson ninja-build
-
       - name: Install GStreamer ≥1.26 dev-packages
         run: |
           apt-get update
@@ -39,7 +33,6 @@ jobs:
             libgstreamer1.0-dev \
             libgstreamer-plugins-base1.0-dev \
             gstreamer1.0-tools
-
       - name: Install build tools & dependencies
         run: |
           apt-get install -y \
@@ -54,10 +47,10 @@ jobs:
             gstreamer1.0-libav \
             gnulib autopoint gperf gtk-doc-tools nettle-dev \
             clang libtasn1-bin libtasn1-6-dev libunistring-dev \
-            libp11-kit-dev libunbound-dev wget gtk-doc-tools libswscale-dev libswresample-dev \
-            nasm
+            libp11-kit-dev libunbound-dev wget gtk-doc-tools libswscale-dev libswresample-dev nasm \
+            python3-pip flex bison libgirepository1.0-dev python3-dev
+          pip3 install --break-system-packages --upgrade meson
 
-      # ───────────── cache the wolfssl/gnutls tool-chain ─────────────
       - name: Restore cached gnutls-wolfssl
         id: cache-gnutls
         uses: actions/cache@v4
@@ -74,20 +67,53 @@ jobs:
         if: steps.cache-gnutls.outputs.cache-hit != 'true'
         run: |
           GNUTLS_INSTALL=/opt/gnutls WOLFSSL_INSTALL=/opt/wolfssl ./setup.sh
-
       - name: Verify GnuTLS install
         run: |
           test -d /opt/gnutls/lib || (echo "/opt/gnutls/lib missing" && exit 1)
 
+      - name: Restore cached GStreamer
+        id: cache-gstreamer
+        uses: actions/cache@v4
+        with:
+          path: /opt/gstreamer
+          key: gstreamer-1.26.2-${{ runner.os }}-bookworm
+          restore-keys: |
+            gstreamer-1.26.2-${{ runner.os }}-
+
+      - name: Build GStreamer 1.26.2 from source
+        if: steps.cache-gstreamer.outputs.cache-hit != 'true'
+        run: |
+          pip3 install --break-system-packages meson ninja
+          git clone https://github.com/GStreamer/gstreamer.git gstreamer-source
+          cd gstreamer-source
+          git checkout 1.26.2
+          meson setup build \
+            --prefix=/opt/gstreamer \
+            --libdir=lib \
+            -Dgood=enabled \
+            -Dbad=enabled \
+            -Dugly=enabled \
+            -Dlibav=disabled \
+            -Ddevtools=disabled \
+            -Dsharp=disabled \
+            -Dpython=disabled \
+            -Drs=disabled \
+            -Dgst-plugins-bad:vulkan=disabled \
+            -Dgst-plugins-bad:nvcodec=disabled \
+            -Dgst-plugins-bad:qsv=disabled
+          ninja -C build
+          ninja -C build install
+          cd ..
+          rm -rf gstreamer-source
       - name: Build FFmpeg with GnuTLS & MPEG-4 encoder
         run: |
           cd $RUNNER_WORKSPACE
           git clone https://git.ffmpeg.org/ffmpeg.git ffmpeg-gnutls
           cd ffmpeg-gnutls
-          export PKG_CONFIG_PATH="/opt/gnutls/lib/pkgconfig"
-          export CPPFLAGS="-I/opt/gnutls/include"
-          export LDFLAGS="-L/opt/gnutls/lib -Wl,-rpath,/opt/gnutls/lib"
-          export LD_LIBRARY_PATH="/opt/gnutls/lib:$LD_LIBRARY_PATH"
+          export PKG_CONFIG_PATH="/opt/gnutls/lib/pkgconfig:/opt/gstreamer/lib/pkgconfig"
+          export CPPFLAGS="-I/opt/gnutls/include -I/opt/gstreamer/include"
+          export LDFLAGS="-L/opt/gnutls/lib -L/opt/gstreamer/lib -Wl,-rpath,/opt/gnutls/lib -Wl,-rpath,/opt/gstreamer/lib"
+          export LD_LIBRARY_PATH="/opt/gnutls/lib:/opt/gstreamer/lib:$LD_LIBRARY_PATH"
           ./configure \
             --prefix=/opt/ffmpeg-gnutls \
             --disable-openssl \
@@ -95,14 +121,13 @@ jobs:
             --enable-encoder=mpeg4 \
             --enable-shared
           make -j"$(nproc)" && make install
-
       - name: Verify libav* link against custom GnuTLS
         run: |
-          export PKG_CONFIG_PATH="/opt/gnutls/lib/pkgconfig:/opt/ffmpeg-gnutls/lib/pkgconfig:$PKG_CONFIG_PATH"
-          export CPPFLAGS="-I/opt/gnutls/include -I/opt/ffmpeg-gnutls/include $CPPFLAGS"
-          export LDFLAGS="-L/opt/gnutls/lib -L/opt/ffmpeg-gnutls/lib \
-            -Wl,-rpath,/opt/gnutls/lib -Wl,-rpath=/opt/ffmpeg-gnutls/lib $LDFLAGS"
-          export LD_LIBRARY_PATH="/opt/gnutls/lib:/opt/ffmpeg-gnutls/lib:$LD_LIBRARY_PATH"
+          export PKG_CONFIG_PATH="/opt/gnutls/lib/pkgconfig:/opt/ffmpeg-gnutls/lib/pkgconfig:/opt/gstreamer/lib/pkgconfig:$PKG_CONFIG_PATH"
+          export CPPFLAGS="-I/opt/gnutls/include -I/opt/ffmpeg-gnutls/include -I/opt/gstreamer/include $CPPFLAGS"
+          export LDFLAGS="-L/opt/gnutls/lib -L/opt/ffmpeg-gnutls/lib -L/opt/gstreamer/lib \
+            -Wl,-rpath,/opt/gnutls/lib -Wl,-rpath=/opt/ffmpeg-gnutls/lib -Wl,-rpath,/opt/gstreamer/lib $LDFLAGS"
+          export LD_LIBRARY_PATH="/opt/gnutls/lib:/opt/ffmpeg-gnutls/lib:/opt/gstreamer/lib:$LD_LIBRARY_PATH"
           for lib in libavformat.so.62 libavfilter.so.11; do
             echo ">>> ldd for $lib:"
             ldd /opt/ffmpeg-gnutls/lib/$lib
@@ -113,50 +138,46 @@ jobs:
             fi
             echo "✔ $lib is using custom GnuTLS"
           done
-
       - name: Clone & checkout gst-libav1.0 @ ${{ matrix.gst_ref }}
         run: |
           git clone https://salsa.debian.org/gstreamer-team/gst-libav1.0.git gst-libav
           cd gst-libav
           git fetch --tags
           git checkout ${{ matrix.gst_ref }}
-
       - name: Build gst-libav1.0 (${{ matrix.gst_ref }})
         working-directory: gst-libav
         run: |
-          export PKG_CONFIG_PATH="/opt/gnutls/lib/pkgconfig:/opt/ffmpeg-gnutls/lib/pkgconfig:$PKG_CONFIG_PATH"
-          export CPPFLAGS="-I/opt/gnutls/include -I/opt/ffmpeg-gnutls/include $CPPFLAGS"
-          export LDFLAGS="-L/opt/gnutls/lib -L/opt/ffmpeg-gnutls/lib \
-            -Wl,-rpath,/opt/gnutls/lib -Wl,-rpath=/opt/ffmpeg-gnutls/lib $LDFLAGS"
-          export LD_LIBRARY_PATH="/opt/gnutls/lib:/opt/ffmpeg-gnutls/lib:$LD_LIBRARY_PATH"
+          export PKG_CONFIG_PATH="/opt/gnutls/lib/pkgconfig:/opt/ffmpeg-gnutls/lib/pkgconfig:/opt/gstreamer/lib/pkgconfig:$PKG_CONFIG_PATH"
+          export CPPFLAGS="-I/opt/gnutls/include -I/opt/ffmpeg-gnutls/include -I/opt/gstreamer/include $CPPFLAGS"
+          export LDFLAGS="-L/opt/gnutls/lib -L/opt/ffmpeg-gnutls/lib -L/opt/gstreamer/lib \
+            -Wl,-rpath,/opt/gnutls/lib -Wl,-rpath=/opt/ffmpeg-gnutls/lib -Wl,-rpath,/opt/gstreamer/lib $LDFLAGS"
+          export LD_LIBRARY_PATH="/opt/gnutls/lib:/opt/ffmpeg-gnutls/lib:/opt/gstreamer/lib:$LD_LIBRARY_PATH"
           rm -rf build
           meson setup build --prefix=/usr -Ddoc=disabled -Dtests=enabled
           ninja -C build
-
       - name: Smoke-test plugin with gst-inspect & playbin
         working-directory: gst-libav
         run: |
-          export PKG_CONFIG_PATH="/opt/gnutls/lib/pkgconfig:/opt/ffmpeg-gnutls/lib/pkgconfig:$PKG_CONFIG_PATH"
-          export CPPFLAGS="-I/opt/gnutls/include -I/opt/ffmpeg-gnutls/include $CPPFLAGS"
-          export LDFLAGS="-L/opt/gnutls/lib -L/opt/ffmpeg-gnutls/lib \
-            -Wl,-rpath,/opt/gnutls/lib -Wl,-rpath=/opt/ffmpeg-gnutls/lib $LDFLAGS"
-          export LD_LIBRARY_PATH="/opt/gnutls/lib:/opt/ffmpeg-gnutls/lib:$LD_LIBRARY_PATH"
+          export PKG_CONFIG_PATH="/opt/gnutls/lib/pkgconfig:/opt/ffmpeg-gnutls/lib/pkgconfig:/opt/gstreamer/lib/pkgconfig:$PKG_CONFIG_PATH"
+          export CPPFLAGS="-I/opt/gnutls/include -I/opt/ffmpeg-gnutls/include -I/opt/gstreamer/include $CPPFLAGS"
+          export LDFLAGS="-L/opt/gnutls/lib -L/opt/ffmpeg-gnutls/lib -L/opt/gstreamer/lib \
+            -Wl,-rpath,/opt/gnutls/lib -Wl,-rpath=/opt/ffmpeg-gnutls/lib -Wl,-rpath,/opt/gstreamer/lib $LDFLAGS"
+          export LD_LIBRARY_PATH="/opt/gnutls/lib:/opt/ffmpeg-gnutls/lib:/opt/gstreamer/lib:$LD_LIBRARY_PATH"
           PAGER=cat \
           GST_PLUGIN_PATH=$(pwd)/build \
-          GST_PLUGIN_SYSTEM_PATH_1_0=/usr/lib/x86_64-linux-gnu/gstreamer-1.0 \
-            gst-inspect-1.0 libav
+          GST_PLUGIN_SYSTEM_PATH_1_0=/opt/gstreamer/lib/gstreamer-1.0 \
+            /opt/gstreamer/bin/gst-inspect-1.0 libav
           timeout 30s env \
             GST_PLUGIN_PATH=$(pwd)/build \
-            GST_PLUGIN_SYSTEM_PATH_1_0=/usr/lib/x86_64-linux-gnu/gstreamer-1.0 \
-            gst-launch-1.0 -v playbin \
+            GST_PLUGIN_SYSTEM_PATH_1_0=/opt/gstreamer/lib/gstreamer-1.0 \
+            /opt/gstreamer/bin/gst-launch-1.0 -v playbin \
               uri=https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8 || test $? -eq 124
-
       - name: Run upstream gst-libav tests
         working-directory: gst-libav
         run: |
-          export PKG_CONFIG_PATH="/opt/gnutls/lib/pkgconfig:/opt/ffmpeg-gnutls/lib/pkgconfig:$PKG_CONFIG_PATH"
-          export CPPFLAGS="-I/opt/gnutls/include -I/opt/ffmpeg-gnutls/include $CPPFLAGS"
-          export LDFLAGS="-L/opt/gnutls/lib -L/opt/ffmpeg-gnutls/lib \
-            -Wl,-rpath,/opt/gnutls/lib -Wl,-rpath=/opt/ffmpeg-gnutls/lib $LDFLAGS"
-          export LD_LIBRARY_PATH="/opt/gnutls/lib:/opt/ffmpeg-gnutls/lib:$LD_LIBRARY_PATH"
+          export PKG_CONFIG_PATH="/opt/gnutls/lib/pkgconfig:/opt/ffmpeg-gnutls/lib/pkgconfig:/opt/gstreamer/lib/pkgconfig:$PKG_CONFIG_PATH"
+          export CPPFLAGS="-I/opt/gnutls/include -I/opt/ffmpeg-gnutls/include -I/opt/gstreamer/include $CPPFLAGS"
+          export LDFLAGS="-L/opt/gnutls/lib -L/opt/ffmpeg-gnutls/lib -L/opt/gstreamer/lib \
+            -Wl,-rpath,/opt/gnutls/lib -Wl,-rpath=/opt/ffmpeg-gnutls/lib -Wl,-rpath,/opt/gstreamer/lib $LDFLAGS"
+          export LD_LIBRARY_PATH="/opt/gnutls/lib:/opt/ffmpeg-gnutls/lib:/opt/gstreamer/lib:$LD_LIBRARY_PATH"
           meson test -C build --print-errorlogs

--- a/.github/workflows/libcamera.yml
+++ b/.github/workflows/libcamera.yml
@@ -19,39 +19,36 @@ jobs:
         libcamera_ref: [ 'master', 'v0.5.1', 'v0.0.3' ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    container:
+      image: debian:bookworm
+      options: --security-opt seccomp=unconfined
     steps:
       - name: Checkout gnutls-wolfssl repository
         uses: actions/checkout@v4
 
-      - name: Setup Python 3.11 for older libcamera
-        if: matrix.libcamera_ref == 'v0.0.3'
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.11'
-
       - name: Ensure make available (Ubuntu only)
         if: matrix.os == 'ubuntu-latest'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential
+          apt-get update
+          apt-get install -y build-essential
 
       - name: Install GnuTLS dependencies (Ubuntu only)
         if: matrix.os == 'ubuntu-latest'
         run: |
-          sudo apt-get install -y gnulib autopoint gperf gtk-doc-tools nettle-dev clang \
+          apt-get install -y gnulib autopoint gperf gtk-doc-tools nettle-dev clang \
             libtasn1-bin libtasn1-6-dev libunistring-dev libp11-kit-dev libunbound-dev \
-            libjpeg-dev
+            libjpeg-dev sudo wget git
 
       - name: Install libcamera dependencies (Ubuntu only)
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get install -y cmake meson ninja-build pkg-config python3-ply \
-            python3-jinja2 python3-yaml libyaml-dev libgtest-dev
+            python3-jinja2 python3-yaml libyaml-dev libgtest-dev python3-pip
 
       - name: Install Python dependencies for v0.0.3
         if: matrix.libcamera_ref == 'v0.0.3'
         run: |
-          python -m pip install ply jinja2 pyyaml
+          python3 -m pip install --break-system-packages ply jinja2 pyyaml
 
       # ───────────── cache the wolfssl/gnutls tool-chain ─────────────
       - name: Restore cached gnutls-wolfssl

--- a/.github/workflows/libcups.yml
+++ b/.github/workflows/libcups.yml
@@ -22,6 +22,8 @@ jobs:
         cups_version: [ 'latest', 'target' ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    container:
+      image: debian:bookworm
 
     steps:
       - name: Checkout gnutls-wolfssl repository
@@ -29,13 +31,13 @@ jobs:
 
       - name: Install build essentials
         run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential
+          apt-get update
+          apt-get install -y build-essential sudo
 
       - name: Install GnuTLS dependencies
         run: |
           sudo apt-get install -y gnulib autopoint gperf gtk-doc-tools nettle-dev clang \
-            libtasn1-bin libtasn1-6-dev libunistring-dev libp11-kit-dev libunbound-dev
+            libtasn1-bin libtasn1-6-dev libunistring-dev libp11-kit-dev libunbound-dev git wget
 
       - name: Install CUPS dependencies
         run: |
@@ -129,6 +131,7 @@ jobs:
           echo "TLS server started successfully with PID $SERVER_PID"
 
       - name: Run tests and analyze results
+        shell: bash
         run: |
           # Determine test directory
           if [ "${{ matrix.cups_version }}" == "latest" ]; then
@@ -137,6 +140,7 @@ jobs:
             TEST_DIR="cups/cups"
           fi
 
+          echo $TEST_DIR
           cd $TEST_DIR
 
           # Run tests WITH provider
@@ -235,3 +239,4 @@ jobs:
             echo "Test Result: FAILURE"
           fi
           echo "=================="
+

--- a/.github/workflows/libjcat.yml
+++ b/.github/workflows/libjcat.yml
@@ -22,6 +22,8 @@ jobs:
         libjcat_ref: [ 'master', '0.2.3', '0.2.0' ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    container:
+      image: debian:bookworm
 
     steps:
       - name: Checkout gnutls-wolfssl repository
@@ -30,14 +32,15 @@ jobs:
       - name: Ensure make available (Ubuntu only)
         if: matrix.os == 'ubuntu-latest'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential
+          apt-get update
+          apt-get install -y build-essential
 
       - name: Install GnuTLS dependencies (Ubuntu only)
         if: matrix.os == 'ubuntu-latest'
         run: |
-          sudo apt-get install -y gnulib autopoint gperf gtk-doc-tools nettle-dev clang \
-            libtasn1-bin libtasn1-6-dev libunistring-dev libp11-kit-dev libunbound-dev
+          apt-get install -y gnulib autopoint gperf gtk-doc-tools nettle-dev clang \
+            libtasn1-bin libtasn1-6-dev libunistring-dev libp11-kit-dev libunbound-dev \
+            sudo wget git
 
       - name: Install libjcat dependencies (Ubuntu only)
         if: matrix.os == 'ubuntu-latest'
@@ -84,7 +87,7 @@ jobs:
         run: |
           mkdir -p ~/.venvs
           python3 -m venv ~/.venvs/meson-056
-          source ~/.venvs/meson-056/bin/activate
+          . ~/.venvs/meson-056/bin/activate
           pip install 'meson==0.56.0'
           export PKG_CONFIG_PATH=/opt/gnutls/lib/pkgconfig:$PKG_CONFIG_PATH
           export CPPFLAGS="-I/opt/gnutls/include $CPPFLAGS"
@@ -95,5 +98,5 @@ jobs:
       - name: Test libjcat Build
         working-directory: libjcat
         run: |
-          source ~/.venvs/meson-056/bin/activate
+          . ~/.venvs/meson-056/bin/activate
           meson test -C _build-custom --verbose

--- a/.github/workflows/libnice.yml
+++ b/.github/workflows/libnice.yml
@@ -20,6 +20,8 @@ jobs:
         libnice_ref: [ 'master', '0.1.22', '0.1.21' ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    container:
+      image: debian:bookworm
 
     steps:
       - uses: actions/checkout@v4
@@ -39,8 +41,8 @@ jobs:
 
       - name: Install build prerequisites
         run: |
-          sudo apt-get update
-          sudo apt-get install -y gnulib autopoint gperf gtk-doc-tools nettle-dev clang libtasn1-bin libtasn1-6-dev libunistring-dev libp11-kit-dev libunbound-dev meson cmake meson ninja-build pkg-config python3-ply python3-jinja2 python3-yaml libyaml-dev libgtest-dev libglib2.0-dev
+          apt-get update
+          apt-get install -y gnulib autopoint gperf gtk-doc-tools nettle-dev clang libtasn1-bin libtasn1-6-dev libunistring-dev libp11-kit-dev libunbound-dev meson cmake meson ninja-build pkg-config python3-ply python3-jinja2 python3-yaml libyaml-dev libgtest-dev libglib2.0-dev sudo wget git
 
       - name: Build custom GnuTLS (wolfSSL provider)
         if: steps.cache-gnutls.outputs.cache-hit != 'true'

--- a/.github/workflows/libvnc.yml
+++ b/.github/workflows/libvnc.yml
@@ -20,6 +20,8 @@ jobs:
         libvnc_ref: [ 'master', 'LibVNCServer-0.9.14' ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    container:
+      image: debian:bookworm
 
     steps:
       - name: Checkout gnutls-wolfssl repository
@@ -27,14 +29,14 @@ jobs:
 
       - name: Install core build tools
         run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential sudo
+          apt-get update
+          apt-get install -y build-essential sudo
 
       - name: Install GnuTLS build dependencies
         run: |
-          sudo apt-get install -y gnulib autopoint gperf gtk-doc-tools \
+          apt-get install -y gnulib autopoint gperf gtk-doc-tools \
             nettle-dev clang libtasn1-bin libtasn1-6-dev libunistring-dev \
-            libp11-kit-dev libunbound-dev wget
+            libp11-kit-dev libunbound-dev wget sudo git cmake
 
       - name: Restore cached gnutls-wolfssl tool-chain
         id: cache-gnutls
@@ -63,7 +65,7 @@ jobs:
       - name: Install libvncserver build dependencies
         run: |
           sudo apt update
-          sudo apt install libsdl2-dev liblzo2-dev libssl-dev \
+          sudo apt install -y libsdl2-dev liblzo2-dev libssl-dev \
           libgcrypt-dev mingw-w64-x86-64-dev binutils-mingw-w64-x86-64 \
           gcc-mingw-w64-x86-64 wine
 

--- a/.github/workflows/libvte.yml
+++ b/.github/workflows/libvte.yml
@@ -20,6 +20,8 @@ jobs:
         vte_ref: [ 'master', '0.70.6']
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    container:
+      image: debian:bookworm
 
     steps:
       - name: Checkout gnutls-wolfssl repository
@@ -27,14 +29,14 @@ jobs:
 
       - name: Install core build tools
         run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential sudo
+          apt-get update
+          apt-get install -y build-essential sudo
 
       - name: Install GnuTLS build dependencies
         run: |
-          sudo apt-get install -y gnulib autopoint gperf gtk-doc-tools \
+          apt-get install -y gnulib autopoint gperf gtk-doc-tools \
             nettle-dev clang libtasn1-bin libtasn1-6-dev libunistring-dev \
-            libp11-kit-dev libunbound-dev wget
+            libp11-kit-dev libunbound-dev wget git sudo
 
       - name: Restore cached gnutls-wolfssl tool-chain
         id: cache-gnutls

--- a/.github/workflows/networkmanager.yml
+++ b/.github/workflows/networkmanager.yml
@@ -13,6 +13,8 @@ concurrency:
 jobs:
   nm-wolfssl-gnutls:
     runs-on: ubuntu-22.04
+    container:
+      image: debian:bookworm
     timeout-minutes: 60
 
     strategy:
@@ -29,8 +31,8 @@ jobs:
 
     - name: Install build dependencies
       run: |
-        sudo apt-get update -qq
-        sudo apt-get install --yes --no-install-recommends \
+        apt-get update -qq
+        apt-get install --yes --no-install-recommends \
           autoconf automake libtool m4 pkg-config build-essential git \
           meson ninja-build gettext clang gperf gnulib autopoint gtk-doc-tools \
           nettle-dev libtasn1-bin libtasn1-6-dev libunistring-dev libnvme-dev \
@@ -40,7 +42,7 @@ jobs:
           libfile-stripnondeterminism-perl libglib2.0-doc \
           libnewt-dev libnl-3-dev libnl-cli-3-200 libnl-nf-3-200 libgirepository1.0-dev \
           libpolkit-agent-1-dev libslang2-dev libsub-override-perl libdbus-1-dev ppp ppp-dev mobile-broadband-provider-info \
-          libteam-dev libteam5 libyaml-perl po-debconf libaudit-dev libudev-dev libsystemd-dev libmm-glib-dev libjansson-dev dhcpcd5 dnsmasq-base libpsl-dev libreadline-dev valac
+          libteam-dev libteam5 libyaml-perl po-debconf libaudit-dev libudev-dev libsystemd-dev libmm-glib-dev libjansson-dev dhcpcd5 dnsmasq-base libpsl-dev libreadline-dev valac sudo git wget
 
     # ──────────────────────── cache the tool-chain ─────────────────────────
     - name: Restore cached gnutls-wolfssl

--- a/.github/workflows/openldap.yml
+++ b/.github/workflows/openldap.yml
@@ -22,6 +22,8 @@ jobs:
         openldap_ref: [ 'master', 'OPENLDAP_REL_ENG_2_5_13', 'OPENLDAP_REL_ENG_2_6_9' ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    container:
+      image: debian:bookworm
 
     steps:
       - name: Checkout gnutls-wolfssl repository
@@ -30,14 +32,15 @@ jobs:
       - name: Ensure make available (Ubuntu only)
         if: matrix.os == 'ubuntu-latest'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential
+          apt-get update
+          apt-get install -y build-essential
 
       - name: Install GnuTLS dependencies (Ubuntu only)
         if: matrix.os == 'ubuntu-latest'
         run: |
-          sudo apt-get install -y gnulib autopoint gperf gtk-doc-tools nettle-dev clang \
-            libtasn1-bin libtasn1-6-dev libunistring-dev libp11-kit-dev libunbound-dev
+          apt-get install -y gnulib autopoint gperf gtk-doc-tools nettle-dev clang \
+            libtasn1-bin libtasn1-6-dev libunistring-dev libp11-kit-dev libunbound-dev sudo \
+            git wget
 
       - name: Install OpenLDAP dependencies (Ubuntu only)
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/qpdf.yml
+++ b/.github/workflows/qpdf.yml
@@ -22,6 +22,8 @@ jobs:
         qpdf_ref: [ 'main', 'v11.3.0', 'v12.2.0' ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    container:
+      image: debian:bookworm
 
     steps:
       - name: Checkout gnutls-wolfssl repository
@@ -30,14 +32,15 @@ jobs:
       - name: Ensure make available (Ubuntu only)
         if: matrix.os == 'ubuntu-latest'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential
+          apt-get update
+          apt-get install -y build-essential
 
       - name: Install GnuTLS dependencies (Ubuntu only)
         if: matrix.os == 'ubuntu-latest'
         run: |
-          sudo apt-get install -y gnulib autopoint gperf gtk-doc-tools nettle-dev clang \
-            libtasn1-bin libtasn1-6-dev libunistring-dev libp11-kit-dev libunbound-dev
+          apt-get install -y gnulib autopoint gperf gtk-doc-tools nettle-dev clang \
+            libtasn1-bin libtasn1-6-dev libunistring-dev libp11-kit-dev libunbound-dev \
+            sudo wget git
 
       - name: Install qpdf dependencies (Ubuntu only)
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/rsyslog.yml
+++ b/.github/workflows/rsyslog.yml
@@ -22,6 +22,8 @@ jobs:
         rsyslog_ref: [ 'main', 'v8.2302.0' ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    container:
+      image: debian:bookworm
 
     steps:
       - name: Checkout gnutls-wolfssl repository
@@ -30,8 +32,8 @@ jobs:
       - name: Ensure make available (Ubuntu only)
         if: matrix.os == 'ubuntu-latest'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential
+          apt-get update
+          apt-get install -y build-essential sudo wget git
 
       - name: Install GnuTLS dependencies (Ubuntu only)
         if: matrix.os == 'ubuntu-latest'
@@ -42,9 +44,10 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get install -y build-essential pkg-config libestr-dev libfastjson-dev zlib1g-dev uuid-dev libhiredis-dev uuid-dev flex bison
-          sudo apt-get install -y libdbi-dev libmysqlclient-dev postgresql-client libpq-dev libnet-dev librdkafka-dev libpcre3-dev libtokyocabinet-dev libglib2.0-dev libmongo-client-dev
+          sudo apt-get install -y libdbi-dev libmariadb-dev-compat postgresql-client libpq-dev libnet-dev librdkafka-dev libpcre3-dev libtokyocabinet-dev libglib2.0-dev libmongo-client-dev
           sudo apt-get install -y libcurl4-gnutls-dev
-          sudo pip install docutils
+          apt-get install -y python3-pip
+          pip3 install --break-system-packages docutils
 
       - name: Install build and test dependencies (Ubuntu only)
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/rtmp.yml
+++ b/.github/workflows/rtmp.yml
@@ -22,6 +22,8 @@ jobs:
         rtmpdump_ref: [ 'master', 'fa8646d' ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    container:
+      image: debian:bookworm
 
     steps:
       - name: Checkout gnutls-wolfssl repository
@@ -30,14 +32,15 @@ jobs:
       - name: Ensure make available (Ubuntu only)
         if: matrix.os == 'ubuntu-latest'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential
+          apt-get update
+          apt-get install -y build-essential
 
       - name: Install GnuTLS dependencies (Ubuntu only)
         if: matrix.os == 'ubuntu-latest'
         run: |
-          sudo apt-get install -y gnulib autopoint gperf gtk-doc-tools nettle-dev clang \
-            libtasn1-bin libtasn1-6-dev libunistring-dev libp11-kit-dev libunbound-dev
+          apt-get install -y gnulib autopoint gperf gtk-doc-tools nettle-dev clang \
+            libtasn1-bin libtasn1-6-dev libunistring-dev libp11-kit-dev libunbound-dev \
+            sudo wget git
 
       - name: Install RTMPDump dependencies (Ubuntu only)
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/tpm2-tools.yml
+++ b/.github/workflows/tpm2-tools.yml
@@ -12,7 +12,10 @@ concurrency:
 
 jobs:
   tpm2-wolfssl-gnutls-integration:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
+    container:
+      image: debian:bookworm
+      options: --security-opt seccomp=unconfined
     timeout-minutes: 60
     strategy:
       matrix:
@@ -28,14 +31,16 @@ jobs:
       
       - name: Install build dependencies
         run: |
-          sudo apt-get update -qq
+          apt-get update -qq
+          apt-get install -y sudo wget git
           sudo apt-get install --yes --no-install-recommends \
             autoconf automake libtool m4 pkg-config build-essential git \
             meson ninja-build gettext clang gperf gnulib autopoint \
             gtk-doc-tools nettle-dev libtasn1-bin libtasn1-6-dev \
             libunistring-dev libp11-kit-dev libunbound-dev bison python3-yaml \
             libcurl4-openssl-dev libdbus-1-dev libcmocka-dev expect xxd pandoc \
-            libssl-dev libgmp-dev libjson-c-dev libtss2-dev swtpm autoconf-archive
+            libssl-dev libgmp-dev libjson-c-dev libltdl-dev libtss2-dev swtpm autoconf-archive \
+            uuid-dev iproute2 libglib2.0-dev dbus-x11
       
       - name: Build wolfSSL, wrapper and GnuTLS
         run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -22,6 +22,8 @@ jobs:
           - "GNUTLS_NO_PROVIDER=1"
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    container:
+        image: debian:bookworm
 
     steps:
       - name: Checkout repository
@@ -30,9 +32,9 @@ jobs:
       - name: Install dependencies (Ubuntu only)
         if: matrix.os == 'ubuntu-latest'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y gnulib autopoint gperf gtk-doc-tools nettle-dev clang \
-            libtasn1-bin libtasn1-6-dev libunistring-dev libp11-kit-dev libunbound-dev
+          apt-get update
+          apt-get install -y git gnulib autopoint gperf gtk-doc-tools nettle-dev clang \
+            libtasn1-bin libtasn1-6-dev wget libunistring-dev libp11-kit-dev libunbound-dev sudo
 
       # ─────────────── cache the wolfssl/gnutls tool-chain ────────────────
       - name: Restore cached gnutls-wolfssl
@@ -67,6 +69,8 @@ jobs:
     name: Run Valgrind Tests
     timeout-minutes: 30
     runs-on: ubuntu-latest
+    container:
+        image: debian:bookworm
 
     steps:
       - name: Checkout repository
@@ -74,9 +78,9 @@ jobs:
 
       - name: Install Valgrind and dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y valgrind gnulib autopoint gperf gtk-doc-tools nettle-dev clang \
-            libtasn1-bin libtasn1-6-dev libunistring-dev libp11-kit-dev libunbound-dev
+          apt-get update
+          apt-get install -y valgrind git wget gnulib autopoint gperf gtk-doc-tools nettle-dev clang \
+            libtasn1-bin libtasn1-6-dev libunistring-dev libp11-kit-dev libunbound-dev sudo
 
       # ─────────────── cache the wolfssl/gnutls tool-chain ────────────────
       - name: Restore cached gnutls-wolfssl

--- a/.github/workflows/wget.yml
+++ b/.github/workflows/wget.yml
@@ -22,6 +22,8 @@ jobs:
         wget_ref: [ 'master', 'v1.21.3', 'v1.24.5' ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    container:
+      image: debian:bookworm
 
     steps:
       - name: Checkout gnutls-wolfssl repository
@@ -30,14 +32,15 @@ jobs:
       - name: Ensure make available (Ubuntu only)
         if: matrix.os == 'ubuntu-latest'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential
+          apt-get update
+          apt-get install -y build-essential
 
       - name: Install GnuTLS dependencies (Ubuntu only)
         if: matrix.os == 'ubuntu-latest'
         run: |
-          sudo apt-get install -y gnulib autopoint gperf gtk-doc-tools nettle-dev clang \
-            libtasn1-bin libtasn1-6-dev libunistring-dev libp11-kit-dev libunbound-dev
+          apt-get install -y gnulib autopoint gperf gtk-doc-tools nettle-dev clang \
+            libtasn1-bin libtasn1-6-dev libunistring-dev libp11-kit-dev libunbound-dev \
+            sudo wget git flex
 
       - name: Install wget dependencies (Ubuntu only)
         if: matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
- migrated all the workflows from ubuntu to debian:bookworm (12);
- using find instead of `git -C` to find all the files in the clang-tidy.yml for permission reasons;
- exporting `USER=root` in the curl.yml before running the testsuite, that's not set as default in the debian based container;
- Glib in debian bookworm emits Warning for invalid properties while Ubuntu's glib emits critical, addressed this in the fwupd.yml workflow. It affects only the latest version and main, since the target version was built with the same glib version as debian bookworm;
- Building and caching gstramer 1.26.2 in the gst-libavt1.0.yml (ubuntu ships with 1.22, which doesn't satisfy gst-libav's requirements);