### PR TITLE
Removing aes-cfb from the algorithms list when running FIPS mode.

### DIFF
--- a/.github/workflows/gst-libav1.0.yml
+++ b/.github/workflows/gst-libav1.0.yml
@@ -54,7 +54,8 @@ jobs:
             gstreamer1.0-libav \
             gnulib autopoint gperf gtk-doc-tools nettle-dev \
             clang libtasn1-bin libtasn1-6-dev libunistring-dev \
-            libp11-kit-dev libunbound-dev wget gtk-doc-tools libswscale-dev libswresample-dev
+            libp11-kit-dev libunbound-dev wget gtk-doc-tools libswscale-dev libswresample-dev \
+            nasm
 
       # ───────────── cache the wolfssl/gnutls tool-chain ─────────────
       - name: Restore cached gnutls-wolfssl
@@ -92,7 +93,6 @@ jobs:
             --disable-openssl \
             --enable-gnutls \
             --enable-encoder=mpeg4 \
-            --disable-x86asm \
             --enable-shared
           make -j"$(nproc)" && make install
 

--- a/setup.sh
+++ b/setup.sh
@@ -94,7 +94,7 @@ if [ $FIPS_MODE -eq 1 ]; then
             cd fips-v5-checkout
         fi
 
-        ./configure --prefix=$WOLFSSL_INSTALL/ CC=clang --enable-cmac --enable-aesccm --enable-aescfb --enable-keygen 'CFLAGS=-DWOLFSSL_PUBLIC_ASN -DHAVE_PUBLIC_FFDHE -DHAVE_FFDHE_3072 -DHAVE_FFDHE_4096 -DWOLFSSL_DH_EXTRA -DWOLFSSL_PSS_SALT_LEN_DISCOVER -DWOLFSSL_PUBLIC_MP -DWOLFSSL_RSA_KEY_CHECK -DNO_MD5' --enable-fips=v5
+        ./configure --prefix=$WOLFSSL_INSTALL/ CC=clang --enable-cmac --enable-aesccm --enable-keygen 'CFLAGS=-DWOLFSSL_PUBLIC_ASN -DHAVE_PUBLIC_FFDHE -DHAVE_FFDHE_3072 -DHAVE_FFDHE_4096 -DWOLFSSL_DH_EXTRA -DWOLFSSL_PSS_SALT_LEN_DISCOVER -DWOLFSSL_PUBLIC_MP -DWOLFSSL_RSA_KEY_CHECK -DNO_MD5' --enable-fips=v5
 
         make
 

--- a/wolfssl-gnutls-wrapper/tests/test_aescfb8.c
+++ b/wolfssl-gnutls-wrapper/tests/test_aescfb8.c
@@ -139,11 +139,19 @@ static int test_aescfb8(gnutls_cipher_algorithm_t cipher,
 int main(void)
 {
     int ret;
+    int fips_mode;
 
     /* Initialize GnuTLS */
     if ((ret = gnutls_global_init()) < 0) {
         print_gnutls_error("initializing GnuTLS", ret);
         return 1;
+    }
+
+    /* Check if FIPS mode is enabled */
+    fips_mode = gnutls_fips140_mode_enabled();
+    if (fips_mode != 0) {
+        printf("This test can be run only when FIPS140 mode is not enabled\n");
+        return 0; /* Skip test */
     }
 
     ret = test_aescfb8(GNUTLS_CIPHER_AES_128_CFB8, key_128, sizeof(key_128),


### PR DESCRIPTION
Tested locally with FIPS mode on.