### PR TITLE
FHS nuance fix for conflicts when GNUTLS_INSTALL=/usr

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Wrapper-load smoke test
         run: |
           set -e
-          OUT=$(WGW_LOGGING=1 /opt/gnutls/bin/gnutls-cli --version 2>&1 || true)
+          OUT=$(WGW_LOGGING=1 gnutls-cli --version 2>&1 || true)
           echo "$OUT"
           echo "$OUT" | grep -q "ENTER: _gnutls_wolfssl_init" \
             || { echo "::error ::wrapper not initialised – FAIL"; exit 1; }

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,11 @@ fips-*
 /wolfssl-gnutls-wrapper/.cache/
 /wolfssl-gnutls-wrapper/compile_commands.json
 /wolfssl-gnutls-wrapper/tidy-fixes.yaml
+debian/.debhelper/
+debian/debhelper-build-stamp
+debian/files
+debian/gnutls-build/
+debian/gnutls-wolfssl.install
+debian/gnutls-wolfssl.substvars
+debian/gnutls-wolfssl/
+debian/tmp/

--- a/debian/control
+++ b/debian/control
@@ -31,10 +31,16 @@ Rules-Requires-Root: no
 Package: gnutls-wolfssl
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
+Provides: libgnutls30 (= 3.8.9)
+Conflicts: libgnutls30
+Replaces: libgnutls30
 Section: libs
-Description: GnuTLS linked against wolfSSL (/opt prefix)
+Description: GnuTLS linked against wolfSSL
  GnuTLS 3.x rebuilt to use wolfSSL as its cryptographic backend.
- Installs under /opt/gnutls (To prevent conflicts).
+ Installs to standard system locations (/usr/lib, /usr/bin, etc.).
+ .
+ This package provides a drop-in replacement for libgnutls30, satisfying
+ all dependencies while using wolfSSL as the cryptographic backend.
 
 Package: wolfssl-gnutls-wrapper
 Architecture: any

--- a/debian/rules
+++ b/debian/rules
@@ -1,12 +1,12 @@
 #!/usr/bin/make -f
 
-GNUTLS_INSTALL ?= /opt/gnutls
+GNUTLS_BUILD_DIR := $(CURDIR)/debian/gnutls-build
+GNUTLS_INSTALL ?= $(GNUTLS_BUILD_DIR)
 PROVIDER_PATH ?= /opt/wolfssl-gnutls-wrapper
 
 export GNUTLS_INSTALL
 export PROVIDER_PATH
 
-GNUTLS_INSTALL_REL := $(patsubst /%,%,$(GNUTLS_INSTALL))
 PROVIDER_PATH_REL := $(patsubst /%,%,$(PROVIDER_PATH))
 
 FIPS_ARG :=
@@ -27,21 +27,36 @@ endif
 	dh $@ --buildsystem=makefile
 
 override_dh_auto_configure:
-	echo "$(GNUTLS_INSTALL_REL)/*" > debian/gnutls-wolfssl.install
+	echo "usr/lib/*" > debian/gnutls-wolfssl.install
+	echo "usr/bin/*" >> debian/gnutls-wolfssl.install
+	echo "usr/include/*" >> debian/gnutls-wolfssl.install
+	echo "usr/share/*" >> debian/gnutls-wolfssl.install
 	echo "$(PROVIDER_PATH_REL)/*" > debian/wolfssl-gnutls-wrapper.install
 
 override_dh_auto_build:
 	:
 
 override_dh_auto_install:
-	-sudo rm -rf $(GNUTLS_INSTALL) $(PROVIDER_PATH)
-	
+	mkdir -p $(GNUTLS_BUILD_DIR)
+
 	./setup.sh $(FIPS_ARG)
-	
-	mkdir -p $(CURDIR)/debian/tmp$(dir $(GNUTLS_INSTALL))
+
+	mkdir -p $(CURDIR)/debian/tmp/usr
+
+	if [ -d $(GNUTLS_BUILD_DIR)/lib ]; then \
+		cp -a $(GNUTLS_BUILD_DIR)/lib $(CURDIR)/debian/tmp/usr/; \
+	fi
+	if [ -d $(GNUTLS_BUILD_DIR)/bin ]; then \
+		cp -a $(GNUTLS_BUILD_DIR)/bin $(CURDIR)/debian/tmp/usr/; \
+	fi
+	if [ -d $(GNUTLS_BUILD_DIR)/include ]; then \
+		cp -a $(GNUTLS_BUILD_DIR)/include $(CURDIR)/debian/tmp/usr/; \
+	fi
+	if [ -d $(GNUTLS_BUILD_DIR)/share ]; then \
+		cp -a $(GNUTLS_BUILD_DIR)/share $(CURDIR)/debian/tmp/usr/; \
+	fi
+
 	mkdir -p $(CURDIR)/debian/tmp$(dir $(PROVIDER_PATH))
-	
-	cp -a $(GNUTLS_INSTALL) $(CURDIR)/debian/tmp$(GNUTLS_INSTALL)
 	cp -a $(PROVIDER_PATH) $(CURDIR)/debian/tmp$(PROVIDER_PATH)
 
 override_dh_clean:

--- a/wolfssl-gnutls-wrapper/tests/Makefile
+++ b/wolfssl-gnutls-wrapper/tests/Makefile
@@ -1,4 +1,4 @@
-TESTS = test_hash test_long_hash test_shake test_aescbc test_aescfb8 test_aesgcm test_aesccm test_aesxts test_hmac test_cmac test_gmac test_rnd test_rnd_fork test_tls_prf test_hkdf test_pbkdf2 test_ecdsa_sign_and_verify test_ecdh_encrypt_and_decrypt test_eddsa_sign_and_verify test_rsa_sign_and_verify test_rsa_encrypt_and_decrypt test_dh_encrypt_and_decrypt test_pk_import_export test_long_hash test_fips test_aessiv
+TESTS = test_hash test_shake test_aescbc test_aescfb8 test_aesgcm test_aesccm test_aesxts test_hmac test_cmac test_gmac test_rnd test_rnd_fork test_tls_prf test_hkdf test_pbkdf2 test_ecdsa_sign_and_verify test_ecdh_encrypt_and_decrypt test_eddsa_sign_and_verify test_rsa_sign_and_verify test_rsa_encrypt_and_decrypt test_dh_encrypt_and_decrypt test_pk_import_export test_long_hash test_fips test_aessiv
 
 PKGCONF ?= pkg-config
 UNAME_S := $(shell uname -s)
@@ -7,12 +7,27 @@ UNAME_S := $(shell uname -s)
 GNUTLS_PREFIX  := $(if $(GNUTLS_INSTALL),$(GNUTLS_INSTALL),/opt/gnutls)
 PROVIDER_PATH  := $(if $(PROVIDER_PATH),$(PROVIDER_PATH),/opt/wolfssl-gnutls-wrapper)
 
-# Use a *scoped* pkg-config for GnuTLS only (no global fallback).
-# PKG_CONFIG_LIBDIR overrides default search dirs so we don't touch system /usr.
-GNUTLS_PKGCONF := PKG_CONFIG_LIBDIR=$(GNUTLS_PREFIX)/lib/pkgconfig $(PKGCONF)
-
-# Detect pkg-config availability of gnutls (ONLY under GNUTLS_PREFIX)
-HAVE_PC_GNUTLS := $(shell $(GNUTLS_PKGCONF) --exists gnutls && echo yes || echo no)
+# Auto-detect GnuTLS location:
+# 1. If GNUTLS_INSTALL is set, use scoped pkg-config lookup
+# 2. If not set, first try system pkg-config (for Debian packages installed to /usr)
+# 3. Otherwise fall back to /opt/gnutls
+ifdef GNUTLS_INSTALL
+  # Use scoped pkg-config for the specified prefix
+  GNUTLS_PKGCONF := PKG_CONFIG_LIBDIR=$(GNUTLS_PREFIX)/lib/pkgconfig $(PKGCONF)
+  HAVE_PC_GNUTLS := $(shell $(GNUTLS_PKGCONF) --exists gnutls && echo yes || echo no)
+else
+  # Try system pkg-config first (no PKG_CONFIG_LIBDIR restriction)
+  HAVE_PC_GNUTLS := $(shell $(PKGCONF) --exists gnutls && echo yes || echo no)
+  ifeq ($(HAVE_PC_GNUTLS),yes)
+    # Found via system pkg-config, update GNUTLS_PREFIX to match
+    GNUTLS_PREFIX := $(shell $(PKGCONF) --variable=prefix gnutls)
+    GNUTLS_PKGCONF := $(PKGCONF)
+  else
+    # Fall back to /opt/gnutls
+    GNUTLS_PKGCONF := PKG_CONFIG_LIBDIR=$(GNUTLS_PREFIX)/lib/pkgconfig $(PKGCONF)
+    HAVE_PC_GNUTLS := $(shell $(GNUTLS_PKGCONF) --exists gnutls && echo yes || echo no)
+  endif
+endif
 
 ifeq ($(HAVE_PC_GNUTLS),yes)
   GNUTLS_CFLAGS := $(shell $(GNUTLS_PKGCONF) --cflags gnutls)


### PR DESCRIPTION
FHS nuance fixed when providing /usr as GNUTLS_INSTALL (proper dir splitting when installing via debian builder).
Tested with all the configurations from the README + debian testing with fips on/off.