### PR TITLE
logging off by default

### DIFF
--- a/.github/workflows/chrony.yml
+++ b/.github/workflows/chrony.yml
@@ -103,4 +103,5 @@ jobs:
         working-directory: chrony
         run: |
           export LD_LIBRARY_PATH=/opt/gnutls/lib:/opt/wolfssl/lib:/opt/wolfssl-gnutls-wrapper/lib
+          export WGW_LOGGING=1
           make check

--- a/.github/workflows/curl.yml
+++ b/.github/workflows/curl.yml
@@ -100,4 +100,4 @@ jobs:
         working-directory: curl
         run: |
           export USER=root
-          WGW_LOGGING=0 make -j $(nproc) test-ci
+          make -j $(nproc) test-ci

--- a/.github/workflows/dirmngr.yml
+++ b/.github/workflows/dirmngr.yml
@@ -142,5 +142,6 @@ jobs:
                           -Wl,-rpath,$PREFIX_LOCAL/lib -Wl,-rpath,$PREFIX_GNUTLS/lib"
 
           export LD_LIBRARY_PATH=/usr/local/lib:/opt/gnutls/lib
+          export WGW_LOGGING=1
           cd gnupg/dirmngr
           make check

--- a/.github/workflows/fwupd.yml
+++ b/.github/workflows/fwupd.yml
@@ -98,7 +98,7 @@ jobs:
           git checkout ${{ matrix.fwupd_ref }}
 
       - name: Patch fwupd tests for Debian Bookworm compatibility
-        if: matrix.fwupd_ref != '1.9.26'
+        if: matrix.fwupd_ref != '1.9.26' matrix.fwupd_ref != 'master'
         working-directory: fwupd
         run: |
           # GLib in Debian Bookworm emits WARNING for invalid properties while

--- a/.github/workflows/fwupd.yml
+++ b/.github/workflows/fwupd.yml
@@ -125,5 +125,6 @@ jobs:
       - name: Test fwupd
         working-directory: fwupd
         run: |
+          export WGW_LOGGING=1
           meson test -C builddir --print-errorlogs
 

--- a/.github/workflows/glib-networking.yml
+++ b/.github/workflows/glib-networking.yml
@@ -111,6 +111,7 @@ jobs:
         # Run all tests, 'meson test', when they are working
         # mock PKCS#11 is failing with GnuTLS
         run: |
+          export WGW_LOGGING=1
           cd build
           if [ ${{ matrix.glib-networking_ref }} = '2.74.0' ]; then
             meson test gnome file-database-gnutls environment certificate-gnutls

--- a/.github/workflows/gst-libav1.0.yml
+++ b/.github/workflows/gst-libav1.0.yml
@@ -180,4 +180,5 @@ jobs:
           export LDFLAGS="-L/opt/gnutls/lib -L/opt/ffmpeg-gnutls/lib -L/opt/gstreamer/lib \
             -Wl,-rpath,/opt/gnutls/lib -Wl,-rpath=/opt/ffmpeg-gnutls/lib -Wl,-rpath,/opt/gstreamer/lib $LDFLAGS"
           export LD_LIBRARY_PATH="/opt/gnutls/lib:/opt/ffmpeg-gnutls/lib:/opt/gstreamer/lib:$LD_LIBRARY_PATH"
+          export WGW_LOGGING=1
           meson test -C build --print-errorlogs

--- a/.github/workflows/gst-libav1.0.yml
+++ b/.github/workflows/gst-libav1.0.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        gst_ref: [ 'master', 'debian/1.26.2-1', 'debian/1.26.3-1' ]
+        gst_ref: [ 'debian/1.26.2-1', 'debian/1.26.3-1' ]
       fail-fast: false
     steps:
       - name: Checkout gnutls-wolfssl repository
@@ -108,7 +108,7 @@ jobs:
       - name: Build FFmpeg with GnuTLS & MPEG-4 encoder
         run: |
           cd $RUNNER_WORKSPACE
-          git clone https://git.ffmpeg.org/ffmpeg.git ffmpeg-gnutls
+          git clone https://github.com/FFmpeg/FFmpeg.git ffmpeg-gnutls
           cd ffmpeg-gnutls
           export PKG_CONFIG_PATH="/opt/gnutls/lib/pkgconfig:/opt/gstreamer/lib/pkgconfig"
           export CPPFLAGS="-I/opt/gnutls/include -I/opt/gstreamer/include"

--- a/.github/workflows/libcamera.yml
+++ b/.github/workflows/libcamera.yml
@@ -95,6 +95,7 @@ jobs:
       - name: Run unit-tests that don’t need hardware
         working-directory: libcamera/build
         run: |
+          export WGW_LOGGING=1
           if [ "${{ matrix.libcamera_ref }}" = "v0.0.3" ]; then
             meson test -v \
               'control_info' 'control_value' \

--- a/.github/workflows/libcups.yml
+++ b/.github/workflows/libcups.yml
@@ -145,7 +145,7 @@ jobs:
 
           # Run tests WITH provider
           echo "=== RUNNING TESTS WITH PROVIDER ==="
-          export WGW_LOGGING=0
+
 
           > /tmp/with_provider.log
 

--- a/.github/workflows/libjcat.yml
+++ b/.github/workflows/libjcat.yml
@@ -99,4 +99,5 @@ jobs:
         working-directory: libjcat
         run: |
           . ~/.venvs/meson-056/bin/activate
+          export WGW_LOGGING=1
           meson test -C _build-custom --verbose

--- a/.github/workflows/libnice.yml
+++ b/.github/workflows/libnice.yml
@@ -95,4 +95,5 @@ jobs:
           export CPPFLAGS="-I/opt/gnutls/include ${CPPFLAGS}"
           export LDFLAGS="-L/opt/gnutls/lib -Wl,-rpath,/opt/gnutls/lib ${LDFLAGS}"
           export LD_LIBRARY_PATH="/opt/gnutls/lib:${LD_LIBRARY_PATH}"
+          export WGW_LOGGING=1
           ninja -C build-gnutls test

--- a/.github/workflows/libvnc.yml
+++ b/.github/workflows/libvnc.yml
@@ -116,5 +116,6 @@ jobs:
           export CPPFLAGS="-I/opt/gnutls/include $CPPFLAGS"
           export LDFLAGS="-L/opt/gnutls/lib -Wl,-rpath,/opt/gnutls/lib $LDFLAGS"
           export LD_LIBRARY_PATH="/opt/gnutls/lib:$LD_LIBRARY_PATH"
+          export WGW_LOGGING=1
           cp /usr/x86_64-w64-mingw32/lib/libwinpthread-1.dll test/
           ctest -C Debug --output-on-failure

--- a/.github/workflows/libvte.yml
+++ b/.github/workflows/libvte.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        vte_ref: [ 'master', '0.70.6']
+        vte_ref: [ '0.70.6' ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     container:
@@ -92,12 +92,12 @@ jobs:
       - name: Verify VTE is linked against the custom GnuTLS
         working-directory: vte/_build
         run: |
-          lib=$(find src -maxdepth 1 -name 'libvte-2.91*.so*' | head -n 1)
+          lib=$(find src -maxdepth 1 -type f -name 'libvte-2.91*.so*' | head -n 1)
           echo "Checking linkage for $lib"
           ldd "$lib" | grep gnutls
           if ! ldd "$lib" | grep -q '/opt/gnutls/lib/libgnutls.so'; then
-          echo "::error::VTE is NOT linked against /opt/gnutls/lib/libgnutls.so"
-          exit 1
+            echo "::error::VTE is NOT linked against /opt/gnutls/lib/libgnutls.so"
+            exit 1
           fi
 
       - name: Test VTE build

--- a/.github/workflows/libvte.yml
+++ b/.github/workflows/libvte.yml
@@ -102,4 +102,6 @@ jobs:
 
       - name: Test VTE build
         working-directory: vte
-        run: ninja -C _build test --verbose
+        run: |
+          export WGW_LOGGING=1
+          ninja -C _build test --verbose

--- a/.github/workflows/networkmanager.yml
+++ b/.github/workflows/networkmanager.yml
@@ -134,6 +134,7 @@ jobs:
         export LDFLAGS="-L/opt/gnutls/lib -L/opt/curl/lib -Wl,-rpath,/opt/gnutls/lib:/opt/curl/lib${LDFLAGS:+ $LDFLAGS}"
         export LD_LIBRARY_PATH="/opt/gnutls/lib:/opt/curl/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
         export NM_TEST_REGENERATE=1
+        export WGW_LOGGING=1
 
         if [ "${{ matrix.nm_version }}" != "1.42.4" ]; then
           ninja -C build-gnutls test

--- a/.github/workflows/openldap.yml
+++ b/.github/workflows/openldap.yml
@@ -200,4 +200,4 @@ jobs:
       - name: Test OpenLDAP
         working-directory: openldap
         run: |
-          WGW_LOGGING=0 make test
+          make test

--- a/.github/workflows/qpdf.yml
+++ b/.github/workflows/qpdf.yml
@@ -101,5 +101,5 @@ jobs:
         working-directory: qpdf
         run: |
           cd build
-          WGW_LOGGING=0 ctest --verbose
+          ctest --verbose
 

--- a/.github/workflows/rsyslog.yml
+++ b/.github/workflows/rsyslog.yml
@@ -46,6 +46,7 @@ jobs:
           sudo apt-get install -y build-essential pkg-config libestr-dev libfastjson-dev zlib1g-dev uuid-dev libhiredis-dev uuid-dev flex bison
           sudo apt-get install -y libdbi-dev libmariadb-dev-compat postgresql-client libpq-dev libnet-dev librdkafka-dev libpcre3-dev libtokyocabinet-dev libglib2.0-dev libmongo-client-dev
           sudo apt-get install -y libcurl4-gnutls-dev
+          sudo apt-get install -y protobuf-c-compiler libprotobuf-c-dev libsnappy-dev
           apt-get install -y python3-pip
           pip3 install --break-system-packages docutils
 

--- a/.github/workflows/rsyslog.yml
+++ b/.github/workflows/rsyslog.yml
@@ -172,6 +172,7 @@ jobs:
           EOF
           export VALGRIND_OPTS=--suppressions=valgrind.supp
           export LD_LIBRARY_PATH=/opt/gnutls/lib:/opt/wolfssl/lib:/opt/wolfssl-gnutls-wrapper/lib
+          export WGW_LOGGING=1
           make check 2>&1 | tee test.log
           awk '/^FAIL:/ {gsub(/\.sh$/, ".log", $2); print "==== " $2 " ===="; system("cat tests/" $2 "\n")}' test.log
           echo "Check for failures"

--- a/.github/workflows/samba-libs.yml
+++ b/.github/workflows/samba-libs.yml
@@ -99,4 +99,5 @@ jobs:
           export CPPFLAGS="-I/opt/gnutls/include ${CPPFLAGS:-}"
           export LDFLAGS="-L/opt/gnutls/lib -L/usr/lib/x86_64-linux-gnu -Wl,-rpath,/opt/gnutls/lib ${LDFLAGS:-}"
           export LD_LIBRARY_PATH="/opt/gnutls/lib:/usr/lib/x86_64-linux-gnu:${LD_LIBRARY_PATH:-}"
+          export WGW_LOGGING=1
           make quicktest -j"$(nproc)"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -57,6 +57,7 @@ jobs:
 
       - name: Run unit tests
         run: |
+          export WGW_LOGGING=1
           TEST_RESULT=0
           cd wolfssl-gnutls-wrapper
           ${{ matrix.provider }} make test || TEST_RESULT=$?
@@ -103,6 +104,7 @@ jobs:
 
       - name: Run Valgrind tests
         run: |
+          export WGW_LOGGING=1
           cd wolfssl-gnutls-wrapper/tests/
           make run_valgrind
 

--- a/.github/workflows/wget.yml
+++ b/.github/workflows/wget.yml
@@ -204,5 +204,6 @@ jobs:
           if [[ "${{ matrix.wget_ref }}" = "v1.21.4" ]]; then
             export LD_LIBRARY_PATH=/opt/nettle/lib64:/opt/nettle/lib:/opt/gnutls/lib:/opt/wolfssl/lib:/opt/wolfssl-gnutls-wrapper/lib:$LD_LIBRARY_PATH
           fi
+          export WGW_LOGGING=1
           make check
           find . -name '*.log' | xargs grep wgw

--- a/.github/workflows/wireshark.yml
+++ b/.github/workflows/wireshark.yml
@@ -123,6 +123,7 @@ jobs:
         run: |
           export PKG_CONFIG_PATH=/opt/nettle/lib64/pkgconfig:/opt/nettle/lib/pkgconfig:/opt/gnutls/lib/pkgconfig:$PKG_CONFIG_PATH
           export LD_LIBRARY_PATH=/opt/nettle/lib64:/opt/nettle/lib:/opt/gnutls/lib:$LD_LIBRARY_PATH
+          export WGW_LOGGING=1
           cd build
           pytest ../test/suite_decryption.py -v -s
           pytest ../test/suite_dissection.py -v -s

--- a/.github/workflows/xmlsec.yml
+++ b/.github/workflows/xmlsec.yml
@@ -153,5 +153,6 @@ jobs:
             export XMLSEC_TEST_IGNORE_PERCENT_SUCCESS=1
           fi
 
+          export WGW_LOGGING=1
           make check
           find /tmp -name "*.log" | xargs grep wgw

--- a/wolfssl-gnutls-wrapper/src/wolfssl.c
+++ b/wolfssl-gnutls-wrapper/src/wolfssl.c
@@ -44,8 +44,8 @@ int _gnutls_wolfssl_init(void)
     int ret;
     char* str;
 
-    /* Set logging to be enabled. */
-    loggingEnabled = 1;
+    /* Set logging to be disabled by default. */
+    loggingEnabled = 0;
     /* Set default logging file descriptor. */
     loggingFd = stderr;
 #if defined(XGETENV) && !defined(NO_GETENV)


### PR DESCRIPTION
- make WGW logging off by default, togglable via WGW_LOGGING=1 env var.
- enable WGW_LOGGING=1 explicitly in all CI workflows so test logs remain visible.