### PR TITLE
ci-cd opt.

### DIFF
--- a/.github/workflows/fwupd.yml
+++ b/.github/workflows/fwupd.yml
@@ -93,12 +93,10 @@ jobs:
 
       - name: Build fwupd at ${{ matrix.fwupd_ref }}
         run: |
-          git clone https://github.com/fwupd/fwupd.git
-          cd fwupd
-          git checkout ${{ matrix.fwupd_ref }}
+          git clone --depth=1 --branch ${{ matrix.fwupd_ref }} https://github.com/fwupd/fwupd.git
 
       - name: Patch fwupd tests for Debian Bookworm compatibility
-        if: matrix.fwupd_ref != '1.9.26' matrix.fwupd_ref != 'master'
+        if: matrix.fwupd_ref != '1.9.26'
         working-directory: fwupd
         run: |
           # GLib in Debian Bookworm emits WARNING for invalid properties while
@@ -107,7 +105,11 @@ jobs:
           # This gets applied only for the latest version and the latest main branch,
           # target version remains untouched since it's using the correct older version
           # of glib that matches the one on debian:bookworm.
-          sed -i 's/GLib-GObject-CRITICAL/GLib-GObject-WARNING/g' libfwupd/fwupd-self-test.c
+          if [ "${{ matrix.fwupd_ref }}" != "main" ]; then
+            sed -i 's/GLib-GObject-CRITICAL/GLib-GObject-WARNING/g' libfwupd/fwupd-self-test.c
+          else
+            sed -i 's/GLib-GObject-CRITICAL/GLib-GObject-WARNING/g' libfwupd/fwupd-client-test.c
+          fi
 
       - name: Configure fwupd
         working-directory: fwupd

--- a/.github/workflows/gst-libav1.0.yml
+++ b/.github/workflows/gst-libav1.0.yml
@@ -84,9 +84,8 @@ jobs:
         if: steps.cache-gstreamer.outputs.cache-hit != 'true'
         run: |
           pip3 install --break-system-packages meson ninja
-          git clone https://github.com/GStreamer/gstreamer.git gstreamer-source
+          git clone --depth=1 --branch 1.26.2 https://github.com/GStreamer/gstreamer.git gstreamer-source
           cd gstreamer-source
-          git checkout 1.26.2
           meson setup build \
             --prefix=/opt/gstreamer \
             --libdir=lib \
@@ -108,9 +107,8 @@ jobs:
       - name: Build FFmpeg with GnuTLS & MPEG-4 encoder
         run: |
           cd $RUNNER_WORKSPACE
-          git clone https://github.com/FFmpeg/FFmpeg.git ffmpeg-gnutls
+          git clone --depth=1 --branch n8.1 https://github.com/FFmpeg/FFmpeg.git ffmpeg-gnutls
           cd ffmpeg-gnutls
-          git checkout n8.1
           export PKG_CONFIG_PATH="/opt/gnutls/lib/pkgconfig:/opt/gstreamer/lib/pkgconfig"
           export CPPFLAGS="-I/opt/gnutls/include -I/opt/gstreamer/include"
           export LDFLAGS="-L/opt/gnutls/lib -L/opt/gstreamer/lib -Wl,-rpath,/opt/gnutls/lib -Wl,-rpath,/opt/gstreamer/lib"
@@ -141,10 +139,7 @@ jobs:
           done
       - name: Clone & checkout gst-libav1.0 @ ${{ matrix.gst_ref }}
         run: |
-          git clone https://salsa.debian.org/gstreamer-team/gst-libav1.0.git gst-libav
-          cd gst-libav
-          git fetch --tags
-          git checkout ${{ matrix.gst_ref }}
+          git clone --depth=1 --branch ${{ matrix.gst_ref }} https://salsa.debian.org/gstreamer-team/gst-libav1.0.git gst-libav
       - name: Build gst-libav1.0 (${{ matrix.gst_ref }})
         working-directory: gst-libav
         run: |

--- a/.github/workflows/libcamera.yml
+++ b/.github/workflows/libcamera.yml
@@ -76,11 +76,7 @@ jobs:
 
       - name: Checkout libcamera at ${{ matrix.libcamera_ref }}
         run: |
-          git clone https://git.libcamera.org/libcamera/libcamera.git
-          cd libcamera
-          if [ "${{ matrix.libcamera_ref }}" != "master" ]; then
-            git checkout ${{ matrix.libcamera_ref }}
-          fi
+          git clone --depth=1 --branch ${{ matrix.libcamera_ref }} https://gitlab.freedesktop.org/camera/libcamera.git
 
       - name: Configure and build libcamera
         working-directory: libcamera

--- a/.github/workflows/libcups.yml
+++ b/.github/workflows/libcups.yml
@@ -77,9 +77,8 @@ jobs:
       - name: Clone and build LibCUPS latest release
         if: matrix.cups_version == 'latest'
         run: |
-          git clone --recurse-submodules https://github.com/OpenPrinting/libcups.git
+          git clone --depth=1 --branch v3.0rc4 --recurse-submodules --shallow-submodules https://github.com/OpenPrinting/libcups.git
           cd libcups
-          git checkout v3.0rc4
 
           export PKG_CONFIG_PATH="/opt/gnutls/lib/pkgconfig:$PKG_CONFIG_PATH"
           export CPPFLAGS="-I/opt/gnutls/include $CPPFLAGS"
@@ -96,9 +95,8 @@ jobs:
       - name: Clone and build CUPS target release (v2.4.2)
         if: matrix.cups_version == 'target'
         run: |
-          git clone https://github.com/OpenPrinting/cups.git
+          git clone --depth=1 --branch v2.4.2 https://github.com/OpenPrinting/cups.git
           cd cups
-          git checkout v2.4.2
 
           export PKG_CONFIG_PATH="/opt/gnutls/lib/pkgconfig:$PKG_CONFIG_PATH"
           export CPPFLAGS="-I/opt/gnutls/include $CPPFLAGS"

--- a/.github/workflows/libjcat.yml
+++ b/.github/workflows/libjcat.yml
@@ -76,11 +76,7 @@ jobs:
 
       - name: Checkout libjcat at ${{ matrix.libjcat_ref }}
         run: |
-          git clone https://github.com/hughsie/libjcat.git
-          cd libjcat
-          if [ "${{ matrix.libjcat_ref }}" != "master" ]; then
-            git checkout ${{ matrix.libjcat_ref }}
-          fi
+          git clone --depth=1 --branch ${{ matrix.libjcat_ref }} https://github.com/hughsie/libjcat.git
 
       - name: Configure and build libjcat
         working-directory: libjcat

--- a/.github/workflows/libnice.yml
+++ b/.github/workflows/libnice.yml
@@ -51,11 +51,7 @@ jobs:
 
       - name: Clone libnice @ ref
         run: |
-          git clone https://github.com/libnice/libnice.git
-          cd libnice
-          if [ "${{ matrix.libnice_ref }}" != "master" ]; then
-            git checkout ${{ matrix.libnice_ref }}
-          fi
+          git clone --depth=1 --branch ${{ matrix.libnice_ref }} https://github.com/libnice/libnice.git
 
       - name: Configure & build with Meson/Ninja
         working-directory: libnice

--- a/.github/workflows/libvnc.yml
+++ b/.github/workflows/libvnc.yml
@@ -71,11 +71,7 @@ jobs:
 
       - name: Checkout libvnc at ${{ matrix.libvnc_ref }}
         run: |
-          git clone https://github.com/LibVNC/libvncserver.git
-          cd libvncserver
-          if [ "${{ matrix.libvnc_ref }}" != "master" ]; then
-            git checkout ${{ matrix.libvnc_ref }}
-          fi
+          git clone --depth=1 --branch ${{ matrix.libvnc_ref }} https://github.com/LibVNC/libvncserver.git
 
       - name: Configure and build libvncserver
         working-directory: libvncserver

--- a/.github/workflows/libvte.yml
+++ b/.github/workflows/libvte.yml
@@ -74,11 +74,7 @@ jobs:
 
       - name: Checkout VTE at ${{ matrix.vte_ref }}
         run: |
-          git clone https://github.com/GNOME/vte.git
-          cd vte
-          if [ "${{ matrix.vte_ref }}" != "master" ]; then
-            git checkout ${{ matrix.vte_ref }}
-          fi
+          git clone --depth=1 --branch ${{ matrix.vte_ref }} https://github.com/GNOME/vte.git
 
       - name: Configure and build VTE
         working-directory: vte

--- a/.github/workflows/networkmanager.yml
+++ b/.github/workflows/networkmanager.yml
@@ -20,131 +20,123 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        nm_version: [ master, "1.52.0", "1.42.4" ]
+        nm_version: [ main, "1.52.0", "1.42.4" ]
 
     steps:
-    # ────────────────────────── checkout + packages ─────────────────────────
-    - name: Checkout repo
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
+      - name: Checkout repo
+        uses: actions/checkout@v4
 
-    - name: Install build dependencies
-      run: |
-        apt-get update -qq
-        apt-get install --yes --no-install-recommends \
-          autoconf automake libtool m4 pkg-config build-essential git \
-          meson ninja-build gettext clang gperf gnulib autopoint gtk-doc-tools \
-          nettle-dev libtasn1-bin libtasn1-6-dev libunistring-dev libnvme-dev \
-          libp11-kit-dev libunbound-dev bison python3-yaml \
-          debhelper debugedit dh-autoreconf dh-strip-nondeterminism dwz intltool \
-          libbluetooth-dev libdebhelper-perl libndp-dev \
-          libfile-stripnondeterminism-perl libglib2.0-doc \
-          libnewt-dev libnl-3-dev libnl-cli-3-200 libnl-nf-3-200 libgirepository1.0-dev \
-          libpolkit-agent-1-dev libslang2-dev libsub-override-perl libdbus-1-dev ppp ppp-dev mobile-broadband-provider-info \
-          libteam-dev libteam5 libyaml-perl po-debconf libaudit-dev libudev-dev libsystemd-dev libmm-glib-dev libjansson-dev dhcpcd5 dnsmasq-base libpsl-dev libreadline-dev valac sudo git wget
+      - name: Install build dependencies
+        run: |
+          apt-get update -qq
+          apt-get install --yes --no-install-recommends \
+            autoconf automake libtool m4 pkg-config build-essential git \
+            meson ninja-build gettext gettext-base \
+            itstool clang gperf gnulib autopoint gtk-doc-tools \
+            nettle-dev libtasn1-bin libtasn1-6-dev libunistring-dev libnvme-dev \
+            libp11-kit-dev libunbound-dev bison \
+            python3-yaml python3-dbus python3-gi \
+            debhelper debugedit dh-autoreconf dh-strip-nondeterminism dwz intltool \
+            libbluetooth-dev libdebhelper-perl libndp-dev \
+            libfile-stripnondeterminism-perl libglib2.0-doc \
+            libnewt-dev libnl-3-dev libnl-cli-3-200 libnl-nf-3-200 libgirepository1.0-dev \
+            libpolkit-agent-1-dev polkitd libslang2-dev libsub-override-perl libdbus-1-dev ppp ppp-dev mobile-broadband-provider-info \
+            libteam-dev libteam5 libyaml-perl po-debconf libaudit-dev libudev-dev libsystemd-dev libmm-glib-dev libjansson-dev dhcpcd5 dnsmasq-base libpsl-dev libreadline-dev valac sudo git wget
 
-    # ──────────────────────── cache the tool-chain ─────────────────────────
-    - name: Restore cached gnutls-wolfssl
-      id: cache-gnutls
-      uses: actions/cache@v4
-      with:
-        path: |
-          /opt/gnutls
-          /opt/wolfssl
-          /opt/wolfssl-gnutls-wrapper
-        key: gnutls-wolfssl-${{ runner.os }}-${{ hashFiles('setup.sh', 'wolfssl-gnutls-wrapper/**', 'wolfssl/**', 'gnutls/**') }}
-        restore-keys: |
-          gnutls-wolfssl-${{ runner.os }}-
+      - name: Restore cached gnutls-wolfssl
+        id: cache-gnutls
+        uses: actions/cache@v4
+        with:
+          path: |
+            /opt/gnutls
+            /opt/wolfssl
+            /opt/wolfssl-gnutls-wrapper
+          key: gnutls-wolfssl-${{ runner.os }}-${{ hashFiles('setup.sh', 'wolfssl-gnutls-wrapper/**', 'wolfssl/**', 'gnutls/**') }}
+          restore-keys: |
+            gnutls-wolfssl-${{ runner.os }}-
 
-    # ───────────────── build the forked GnuTLS stack (if needed) ───────────
-    - name: Build forked GnuTLS stack
-      if: steps.cache-gnutls.outputs.cache-hit != 'true'
-      run: |
-        LOGGING=0 GNUTLS_INSTALL=/opt/gnutls WOLFSSL_INSTALL=/opt/wolfssl ./setup.sh
-        test -d /opt/gnutls && test -d /opt/wolfssl
+      - name: Build forked GnuTLS stack
+        if: steps.cache-gnutls.outputs.cache-hit != 'true'
+        run: |
+          LOGGING=0 GNUTLS_INSTALL=/opt/gnutls WOLFSSL_INSTALL=/opt/wolfssl ./setup.sh
+          test -d /opt/gnutls && test -d /opt/wolfssl
 
-    # ───────────────────────────── curl build ──────────────────────────────
-    - name: Build curl 7.88.1 (GnuTLS backend)
-      run: |
-        git clone --branch curl-7_88_1 https://github.com/curl/curl
-        cd curl
-        autoreconf -fi
-        ./configure --with-gnutls=/opt/gnutls --prefix=/opt/curl \
-                    --disable-static --enable-shared
-        make -j"$(nproc)"
-        sudo make install
-        sudo ldconfig
+      - name: Build curl 7.88.1 (GnuTLS backend)
+        run: |
+          git clone --depth=1 --branch curl-7_88_1 https://github.com/curl/curl
+          cd curl
+          autoreconf -fi
+          ./configure --with-gnutls=/opt/gnutls --prefix=/opt/curl \
+                      --disable-static --enable-shared
+          make -j"$(nproc)"
+          sudo make install
+          sudo ldconfig
 
-    # ────────────────────── NetworkManager build & test ────────────────────
-    - name: Clone NetworkManager ${{ matrix.nm_version }}
-      run: |
-        git clone https://github.com/NetworkManager/NetworkManager
-        cd NetworkManager
-        if [ "${{ matrix.nm_version }}" != "master" ]; then
-          git checkout "${{ matrix.nm_version }}"
-        fi
+      - name: Clone NetworkManager ${{ matrix.nm_version }}
+        run: |
+          git clone --depth=1 --branch "${{ matrix.nm_version }}" https://github.com/NetworkManager/NetworkManager
 
-    - name: Configure & build NetworkManager
-      working-directory: NetworkManager
-      run: |
-        export PKG_CONFIG_PATH="/opt/gnutls/lib/pkgconfig:/opt/curl/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
-        export CPPFLAGS="-I/opt/gnutls/include -I/opt/curl/include${CPPFLAGS:+ $CPPFLAGS}"
-        export LDFLAGS="-L/opt/gnutls/lib -L/opt/curl/lib -Wl,-rpath,/opt/gnutls/lib:/opt/curl/lib${LDFLAGS:+ $LDFLAGS}"
-        export LD_LIBRARY_PATH="/opt/gnutls/lib:/opt/curl/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+      - name: Configure & build NetworkManager
+        working-directory: NetworkManager
+        run: |
+          export PKG_CONFIG_PATH="/opt/gnutls/lib/pkgconfig:/opt/curl/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
+          export CPPFLAGS="-I/opt/gnutls/include -I/opt/curl/include${CPPFLAGS:+ $CPPFLAGS}"
+          export LDFLAGS="-L/opt/gnutls/lib -L/opt/curl/lib -Wl,-rpath,/opt/gnutls/lib:/opt/curl/lib${LDFLAGS:+ $LDFLAGS}"
+          export LD_LIBRARY_PATH="/opt/gnutls/lib:/opt/curl/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 
-        if [ "${{ matrix.nm_version }}" != "master" ]; then
-          meson setup build-gnutls \
-            -Dcrypto=gnutls \
-            -Dtests=yes \
-            -Dsystemd_journal=true \
-            -Dmore_logging=true \
-            -Dqt=false
-        else
-          meson setup build-gnutls \
-            -Dcrypto=gnutls \
-            -Dtests=yes \
-            -Dsystemd_journal=true \
-            -Dmore_logging=true \
-            -Dqt=false \
-            -Dnbft=false
-        fi
+          if [ "${{ matrix.nm_version }}" != "main" ]; then
+            meson setup build-gnutls \
+              -Dcrypto=gnutls \
+              -Dtests=yes \
+              -Dsystemd_journal=true \
+              -Dmore_logging=true \
+              -Dqt=false \
+              -Dsystemdsystemunitdir=no
+          else
+            meson setup build-gnutls \
+              -Dcrypto=gnutls \
+              -Dtests=yes \
+              -Dsystemd_journal=true \
+              -Dmore_logging=true \
+              -Dqt=false \
+              -Dnbft=false \
+              -Dsystemdsystemunitdir=no \
+              -Dsystemdsystemgeneratordir=no \
+              -Dclat=false
+          fi
 
-        ninja -C build-gnutls -j"$(nproc)"
+          ninja -C build-gnutls -j"$(nproc)"
 
-    # ───────────────────── verify linkage (before tests) ────────────────────
-    - name: Verify linkage to /opt/gnutls
-      working-directory: NetworkManager/build-gnutls
-      run: |
-        BIN=src/nmcli/nmcli
-        LIB=$(find src/libnm-client-impl -name 'libnm.so*' -type f | head -n1)
-        for obj in "$BIN" "$LIB"; do
-          echo "::group::ldd $obj"
-          ldd "$obj" | grep -E 'lib(curl|gnutls)'
-          echo "::endgroup::"
-          ldd "$obj" | grep -q '/opt/gnutls/lib/libgnutls.so.30' || exit 1
-        done
+      - name: Verify linkage to /opt/gnutls
+        working-directory: NetworkManager/build-gnutls
+        run: |
+          BIN=src/nmcli/nmcli
+          LIB=$(find src/libnm-client-impl -maxdepth 1 -name 'libnm.so*' -type f | head -n1)
+          for obj in "$BIN" "$LIB"; do
+            echo "::group::ldd $obj"
+            ldd "$obj" | grep -E 'lib(curl|gnutls)'
+            echo "::endgroup::"
+            ldd "$obj" | grep -q '/opt/gnutls/lib/libgnutls.so.30' || exit 1
+          done
 
-    # ────────────────────────── run test-suite ──────────────────────────────
-    - name: Run NetworkManager tests
-      working-directory: NetworkManager
-      run: |
-        export PKG_CONFIG_PATH="/opt/gnutls/lib/pkgconfig:/opt/curl/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
-        export CPPFLAGS="-I/opt/gnutls/include -I/opt/curl/include${CPPFLAGS:+ $CPPFLAGS}"
-        export LDFLAGS="-L/opt/gnutls/lib -L/opt/curl/lib -Wl,-rpath,/opt/gnutls/lib:/opt/curl/lib${LDFLAGS:+ $LDFLAGS}"
-        export LD_LIBRARY_PATH="/opt/gnutls/lib:/opt/curl/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-        export NM_TEST_REGENERATE=1
-        export WGW_LOGGING=1
-
-        if [ "${{ matrix.nm_version }}" != "1.42.4" ]; then
-          ninja -C build-gnutls test
-        else
-       # Skipped on CI because the GitHub Actions kernel lacks the VRF/Team modules and QoS-mapping support that platform/test-link-linux expects, so the test aborts with “Unknown device type / xgress QoS mapping assertion.
-       # Doesn't test any TLS/Crypto capabilities.
-          cd build-gnutls
-          all_tests=$(meson test --list 2>/dev/null)
-          test_list=$(printf '%s\n' "$all_tests" \
-            | grep -v -E '^(platform/test-link-linux)$' \
-            | tr '\n' ' ')
-          meson test $test_list --print-errorlogs
-        fi
+      # Skipped on CI because the GitHub Actions kernel lacks the VRF/Team modules and QoS-mapping support that platform/test-link-linux expects, so the test aborts with “Unknown device type / xgress QoS mapping assertion.
+      # Doesn't test any TLS/Crypto capabilities.
+      - name: Run NetworkManager tests
+        working-directory: NetworkManager
+        run: |
+          export PKG_CONFIG_PATH="/opt/gnutls/lib/pkgconfig:/opt/curl/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
+          export CPPFLAGS="-I/opt/gnutls/include -I/opt/curl/include${CPPFLAGS:+ $CPPFLAGS}"
+          export LDFLAGS="-L/opt/gnutls/lib -L/opt/curl/lib -Wl,-rpath,/opt/gnutls/lib:/opt/curl/lib${LDFLAGS:+ $LDFLAGS}"
+          export LD_LIBRARY_PATH="/opt/gnutls/lib:/opt/curl/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+          export NM_TEST_REGENERATE=1
+          export WGW_LOGGING=1
+          if [ "${{ matrix.nm_version }}" != "1.42.4" ]; then
+            ninja -C build-gnutls test
+          else
+            cd build-gnutls
+            all_tests=$(meson test --list 2>/dev/null)
+            test_list=$(printf '%s\n' "$all_tests" \
+              | grep -v -E '^(platform/test-link-linux)$' \
+              | tr '\n' ' ')
+            meson test $test_list --print-errorlogs
+          fi

--- a/.github/workflows/openldap.yml
+++ b/.github/workflows/openldap.yml
@@ -17,9 +17,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            openldap_ref: 'master'
-            use_container: true
-          - os: ubuntu-latest
             openldap_ref: 'OPENLDAP_REL_ENG_2_5_13'
             use_container: true
           - os: ubuntu-24.04
@@ -67,7 +64,6 @@ jobs:
           sudo mkdir -p /opt/gnutls /opt/wolfssl /opt/wolfssl-gnutls-wrapper /opt/nettle
           sudo chown -R $USER:$USER /opt/gnutls /opt/wolfssl /opt/wolfssl-gnutls-wrapper /opt/nettle
 
-     # ───────────── cache the wolfssl/gnutls tool-chain ─────────────
       - name: Restore cached gnutls-wolfssl
         id: cache-gnutls
         uses: actions/cache@v4
@@ -108,7 +104,6 @@ jobs:
           else
             GNUTLS_INSTALL=/opt/gnutls WOLFSSL_INSTALL=/opt/wolfssl ./setup.sh
           fi
-          # For native runner: also save to cache location
           if [[ "${{ matrix.use_container }}" == "false" ]]; then
             mkdir -p ~/cache
             sudo cp -a /opt/gnutls ~/cache/
@@ -143,11 +138,8 @@ jobs:
 
       - name: Build OpenLDAP at ${{ matrix.openldap_ref }}
         run: |
-          git clone https://git.openldap.org/openldap/openldap.git
-          cd openldap
-          if [ "${{ matrix.openldap_ref }}" != "master" ]; then
-            git checkout ${{ matrix.openldap_ref }}
-          fi
+          git clone --depth 1 --branch "${{ matrix.openldap_ref }}" \
+            https://git.openldap.org/openldap/openldap.git
       - name: Configure OpenLDAP
         working-directory: openldap
         run: |
@@ -196,7 +188,7 @@ jobs:
         working-directory: openldap
         run: |
           make depend
-          make
+          make -j$(nproc)
       - name: Test OpenLDAP
         working-directory: openldap
         run: |

--- a/.github/workflows/qpdf.yml
+++ b/.github/workflows/qpdf.yml
@@ -82,9 +82,7 @@ jobs:
 
       - name: Build qpdf at ${{ matrix.qpdf_ref }}
         run: |
-          git clone https://github.com/qpdf/qpdf.git
-          cd qpdf
-          git checkout ${{ matrix.qpdf_ref }}
+          git clone --depth=1 --branch ${{ matrix.qpdf_ref }} https://github.com/qpdf/qpdf.git
 
       - name: Configure qpdf
         working-directory: qpdf

--- a/.github/workflows/rsyslog.yml
+++ b/.github/workflows/rsyslog.yml
@@ -102,7 +102,16 @@ jobs:
       - name: Configure rsyslog
         working-directory: rsyslog
         run: |
-          ./autogen.sh --enable-gnutls --disable-libgcrypt --enable-testbench --enable-imdiag --enable-omstdout PKG_CONFIG_PATH=/opt/gnutls/lib/pkgconfig
+          # adding --without-valgrind-testbench basically drops the entire *-vg.sh
+          # subset from the make check run.
+          # with valgrind, in this container, rsyslogd starts slowly
+          # and the testbench returns (sometimes, but often enough)
+          # false negatives ("pid no longer active during startup"),
+          # aborting the test test before it exercises
+          # anything (valgrind itself reports 0 errors).
+          # unrelated to the provider, and the provider already has valgrind
+          # coverage in unit-tests.yml.
+          ./autogen.sh --enable-gnutls --disable-libgcrypt --enable-testbench --enable-imdiag --enable-omstdout --without-valgrind-testbench PKG_CONFIG_PATH=/opt/gnutls/lib/pkgconfig
 
       - name: Make rsyslog
         working-directory: rsyslog
@@ -111,73 +120,26 @@ jobs:
 
       - name: Test rsyslog
         working-directory: rsyslog
-        if: ${{ matrix.rsyslog_ref == 'main' }}
-        continue-on-error: true
+        # Run the testbench for both the target version and main. The main
+        # branch can be unstable (https://github.com/rsyslog/rsyslog/issues/5771),
+        # so only tolerate failures there.
+        continue-on-error: ${{ matrix.rsyslog_ref == 'main' }}
         run: |
-          cat <<EOF >> tests/valgrind.supp
-          {
-             pselect_cancel
-             Memcheck:Param
-             pselect6(sig)
-             ...
-             fun:pselect64_syscall
-             fun:pselect
-             ...
-          }
-          {
-             pselect_cancel_2
-             Memcheck:Param
-             pselect6(sig)
-             fun:pselect64_syscall
-             fun:pselect
-             ...
-          }
-          {
-             init_leak_malloc
-             Memcheck:Leak
-             match-leak-kinds: definite
-             fun:malloc
-             obj:*
-             obj:*
-             obj:*
-             obj:*
-             obj:*
-             fun:call_init.part.0
-             fun:call_init
-             fun:_dl_init
-             fun:_dl_catch_exception
-             fun:dl_open_worker
-             fun:dl_open_worker
-             fun:_dl_catch_exception
-             fun:_dl_open
-          }
-          {
-             init_leak_calloc
-             Memcheck:Leak
-             match-leak-kinds: definite
-             fun:calloc
-             obj:*
-             obj:*
-             obj:*
-             obj:*
-             obj:*
-             obj:*
-             obj:*
-             fun:call_init.part.0
-             fun:call_init
-             fun:_dl_init
-             fun:_dl_catch_exception
-             fun:dl_open_worker
-             fun:dl_open_worker
-          }
-          EOF
-          export VALGRIND_OPTS=--suppressions=valgrind.supp
           export LD_LIBRARY_PATH=/opt/gnutls/lib:/opt/wolfssl/lib:/opt/wolfssl-gnutls-wrapper/lib
           export WGW_LOGGING=1
           make check 2>&1 | tee test.log
           awk '/^FAIL:/ {gsub(/\.sh$/, ".log", $2); print "==== " $2 " ===="; system("cat tests/" $2 "\n")}' test.log
           echo "Check for failures"
+          # Gate only on genuine test-result failures (FAIL: <name>.sh). The two
+          # omfile-read-only[-errmsg].sh tests assume a non-root user.
+          # They chmod 0400 an output file and expect the write to be denied so a
+          # fallback action fires. rsyslogd runs as root in the debian:bookworm
+          # container and bypasses the permission, so they fail for environmental
+          # reasons unrelated to the wolfSSL/GnuTLS provider.
+          # Any other functional or TLS failure still fails the job.
           EC=0
-          grep '^FAIL:' test.log && EC=1
+          if grep -E '^FAIL: [^ ]+\.sh' test.log | grep -vE 'omfile-read-only(-errmsg)?\.sh'; then
+            EC=1
+          fi
           exit $EC
 

--- a/.github/workflows/samba-libs.yml
+++ b/.github/workflows/samba-libs.yml
@@ -76,11 +76,8 @@ jobs:
 
       - name: Clone Samba
         run: |
-          git clone https://gitlab.com/samba-team/samba.git samba
-          cd samba
-          if [ "${{ matrix.samba_ref }}" != "master" ]; then
-            git checkout ${{ matrix.samba_ref }}
-          fi
+          git clone --depth=1 --branch "${{ matrix.samba_ref }}" \
+            https://gitlab.com/samba-team/samba.git
 
       - name: Configure & build Samba-libs
         working-directory: samba

--- a/.github/workflows/tpm2-tools.yml
+++ b/.github/workflows/tpm2-tools.yml
@@ -26,9 +26,7 @@ jobs:
     steps:
       - name: Checkout current repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      
+
       - name: Install build dependencies
         run: |
           apt-get update -qq
@@ -42,7 +40,20 @@ jobs:
             libssl-dev libgmp-dev libjson-c-dev libltdl-dev libtss2-dev swtpm autoconf-archive \
             uuid-dev iproute2 libglib2.0-dev dbus-x11
       
+      - name: Restore cached gnutls-wolfssl
+        id: cache-gnutls
+        uses: actions/cache@v4
+        with:
+          path: |
+            /opt/gnutls
+            /opt/wolfssl
+            /opt/wolfssl-gnutls-wrapper
+          key: gnutls-wolfssl-${{ runner.os }}-${{ hashFiles('setup.sh', 'wolfssl-gnutls-wrapper/**', 'wolfssl/**', 'gnutls/**') }}
+          restore-keys: |
+            gnutls-wolfssl-${{ runner.os }}-
+
       - name: Build wolfSSL, wrapper and GnuTLS
+        if: steps.cache-gnutls.outputs.cache-hit != 'true'
         run: |
           GNUTLS_INSTALL=/opt/gnutls WOLFSSL_INSTALL=/opt/wolfssl ./setup.sh
       
@@ -67,7 +78,7 @@ jobs:
       - name: Build curl (GnuTLS backend)
         run: |
           export MAKEFLAGS="-j$(nproc)"
-          git clone --branch curl-8_4_0 https://github.com/curl/curl
+          git clone --depth=1 --branch curl-8_4_0 https://github.com/curl/curl
           cd curl
           autoreconf -fi
           ./configure --with-gnutls=/opt/gnutls --prefix=/opt/curl
@@ -78,9 +89,8 @@ jobs:
       - name: Build tpm2-tss
         run: |
           export MAKEFLAGS="-j$(nproc)"
-          git clone https://github.com/tpm2-software/tpm2-tss
+          git clone --depth=1 --branch 4.1.3 https://github.com/tpm2-software/tpm2-tss
           cd tpm2-tss
-          git checkout 4.1.3
           git submodule update --init --recursive
           ./bootstrap
           export PKG_CONFIG_PATH="/opt/gnutls/lib/pkgconfig:/opt/curl/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
@@ -95,7 +105,7 @@ jobs:
       - name: Build tpm2-abrmd
         run: |
           export MAKEFLAGS="-j$(nproc)"
-          git clone https://github.com/tpm2-software/tpm2-abrmd
+          git clone --depth=1 https://github.com/tpm2-software/tpm2-abrmd
           cd tpm2-abrmd
           ./bootstrap
           export PKG_CONFIG_PATH="/opt/gnutls/lib/pkgconfig:/opt/curl/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
@@ -111,7 +121,7 @@ jobs:
       
       - name: Build IBM swtpm2 simulator
         run: |
-          git clone https://github.com/kgoldman/ibmswtpm2.git
+          git clone --depth=1 https://github.com/kgoldman/ibmswtpm2.git
           make -C ibmswtpm2/src -j"$(nproc)"
           sudo install -m755 ibmswtpm2/src/tpm_server /usr/local/bin
           echo "/usr/local/bin" >> $GITHUB_PATH
@@ -119,17 +129,8 @@ jobs:
       - name: Build tpm2-tools
         run: |
           export MAKEFLAGS="-j$(nproc)"
-          git clone https://github.com/tpm2-software/tpm2-tools
+          git clone --depth=1 --branch ${{ matrix.tpm2_tools_version }} https://github.com/tpm2-software/tpm2-tools
           cd tpm2-tools
-          
-          # Checkout the appropriate version
-          if [ "${{ matrix.tpm2_tools_version }}" != "master" ]; then
-            echo "Checking out tag ${{ matrix.tpm2_tools_version }}"
-            git checkout ${{ matrix.tpm2_tools_version }}
-          else
-            echo "Using master branch"
-          fi
-          
           ./bootstrap
           export PKG_CONFIG_PATH="/opt/gnutls/lib/pkgconfig:/opt/curl/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
           export CPPFLAGS="-I/opt/gnutls/include -I/opt/curl/include${CPPFLAGS:+ $CPPFLAGS}"

--- a/.github/workflows/wget.yml
+++ b/.github/workflows/wget.yml
@@ -62,7 +62,6 @@ jobs:
             libtasn1-bin libtasn1-6-dev libunistring-dev libp11-kit-dev libunbound-dev \
             wget git flex autoconf-archive libhttp-daemon-perl
 
-     # ───────────── cache the wolfssl/gnutls tool-chain ─────────────
       - name: Restore cached gnutls-wolfssl
         id: cache-gnutls
         uses: actions/cache@v4
@@ -174,6 +173,13 @@ jobs:
         run: |
           make -j $(nproc)
       # Get python 3.11 for old versions of wget
+      - name: Cache pyenv Python 3.11.9
+        id: cache-pyenv
+        if: matrix.wget_ref == 'v1.21.3' || matrix.wget_ref == 'v1.21.4'
+        uses: actions/cache@v4
+        with:
+          path: ~/.pyenv
+          key: pyenv-3.11.9-${{ matrix.os }}-${{ matrix.use_container }}
       - name: Install pyenv dependencies
         if: matrix.wget_ref == 'v1.21.3' || matrix.wget_ref == 'v1.21.4'
         run: |
@@ -183,7 +189,7 @@ jobs:
             libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev \
             libffi-dev liblzma-dev
       - name: Install pyenv
-        if: matrix.wget_ref == 'v1.21.3' || matrix.wget_ref == 'v1.21.4'
+        if: (matrix.wget_ref == 'v1.21.3' || matrix.wget_ref == 'v1.21.4') && steps.cache-pyenv.outputs.cache-hit != 'true'
         run: |
           curl https://pyenv.run | bash
       - name: Test wget
@@ -195,7 +201,7 @@ jobs:
             export PATH="$PYENV_ROOT/bin:$PATH"
             eval "$(pyenv init --path)"
             eval "$(pyenv virtualenv-init -)"
-            pyenv install 3.11.9
+            pyenv install -s 3.11.9
             pyenv global 3.11.9
             python --version
           fi
@@ -205,5 +211,5 @@ jobs:
             export LD_LIBRARY_PATH=/opt/nettle/lib64:/opt/nettle/lib:/opt/gnutls/lib:/opt/wolfssl/lib:/opt/wolfssl-gnutls-wrapper/lib:$LD_LIBRARY_PATH
           fi
           export WGW_LOGGING=1
-          make check
+          make check -j"$(nproc)"
           find . -name '*.log' | xargs grep wgw

--- a/.github/workflows/wireshark.yml
+++ b/.github/workflows/wireshark.yml
@@ -90,13 +90,10 @@ jobs:
           echo "GnuTLS version verified: 3.8.11"
       - name: Clone wireshark
         run: |
-          git clone https://github.com/wireshark/wireshark.git
+          git clone --depth=1 --branch ${{ matrix.wireshark_ref }} https://github.com/wireshark/wireshark.git
       - name: Setup and build wireshark
         working-directory: wireshark
         run: |
-          if [[ "${{ matrix.wireshark_ref }}" != "master" ]]; then
-            git checkout ${{ matrix.wireshark_ref }}
-          fi
           sudo ./tools/debian-setup.sh
           sudo ./tools/debian-setup.sh --install-deb-deps
           sudo ./tools/debian-setup.sh --install-test-deps

--- a/.github/workflows/xmlsec.yml
+++ b/.github/workflows/xmlsec.yml
@@ -106,12 +106,11 @@ jobs:
 
       - name: Clone xmlsec
         run: |
-          git clone https://github.com/lsh123/xmlsec.git
+          git clone --depth=1 --branch ${{ matrix.xmlsec_ref }} https://github.com/lsh123/xmlsec.git
 
       - name: Setup and build xmlsec
         working-directory: xmlsec
         run: |
-          git checkout ${{ matrix.xmlsec_ref }}
           export PKG_CONFIG_PATH=/opt/nettle/lib64/pkgconfig:/opt/nettle/lib/pkgconfig:/opt/gnutls/lib/pkgconfig:$PKG_CONFIG_PATH
           export LD_LIBRARY_PATH=/opt/nettle/lib64:/opt/nettle/lib:/opt/gnutls/lib:$LD_LIBRARY_PATH
           ./autogen.sh

--- a/wolfssl-gnutls-wrapper/src/cipher.c
+++ b/wolfssl-gnutls-wrapper/src/cipher.c
@@ -438,9 +438,9 @@ int wolfssl_cipher_setkey(void *_ctx, const void *key, size_t keysize)
     }
 
 #ifdef WOLFSSL_AES_XTS
-    if (ctx->mode == XTS && gnutls_fips140_mode_enabled()) {
-        /* XTS has two AES keys that are no allowed to be the same. */
-        if (XMEMCMP(key, key + exp_key_size / 2, exp_key_size / 2) == 0) {
+    if (ctx->mode == XTS) {
+        /* XTS has two AES keys that are not allowed to be the same. */
+        if (XMEMCMP(key, ((const unsigned char*)key) + exp_key_size / 2, exp_key_size / 2) == 0) {
             WGW_ERROR("XTS keys are the same");
             return GNUTLS_E_INVALID_REQUEST;
         }

--- a/wolfssl-gnutls-wrapper/tests/test_aesxts.c
+++ b/wolfssl-gnutls-wrapper/tests/test_aesxts.c
@@ -1,5 +1,6 @@
 
 #include <gnutls/crypto.h>
+#include <stdlib.h>
 
 #include "test_util.h"
 
@@ -97,15 +98,18 @@ static int test_aesxts(gnutls_cipher_algorithm_t cipher,
     /* Copy plaintext to a non-const buffer for GnuTLS */
     memcpy(plaintext, plaintext_data, sizeof(plaintext_data));
 
-    /* Try bad key - same data for both keys or key too small. */
-    ret = gnutls_cipher_init(&encrypt_handle, cipher, &bad_key, &iv);
-    if (gnutls_fips140_mode_enabled() && ret == 0) {
-        print_gnutls_error("initializing cipher with bad key", ret);
-        return 1;
-    }
-    if (!gnutls_fips140_mode_enabled() && ret != 0) {
-        print_gnutls_error("initializing cipher with bad key", ret);
-        return 1;
+    /* Try bad key - same data for both keys. The wolfSSL provider rejects
+     * identical XTS key halves in all modes; native GnuTLS/Nettle (used when
+     * GNUTLS_NO_PROVIDER=1) accepts them in non-FIPS mode, so only enforce the
+     * rejection when the provider is in use. */
+    if (!getenv("GNUTLS_NO_PROVIDER")) {
+        ret = gnutls_cipher_init(&encrypt_handle, cipher, &bad_key, &iv);
+        if (ret == 0) {
+            gnutls_cipher_deinit(encrypt_handle);
+            fprintf(stderr, "Unexpected success initializing "
+                    "cipher with bad XTS key\n");
+            return 1;
+        }
     }
 
     /********** ENCRYPTION TEST **********/


### PR DESCRIPTION
- parallelize the build in openldap.yml and don't clone the full history;
- removing master from the testing matrix of openldap (not a target
  version);
- Enforce distinct aes-xts keys in both fips and non-fips modes (not only fips) to match wolfssl master, and update the test accordingly;
- Skip this check when the provider is not used, since the default nettle
library accepts the keys to be the same;
- cache the pyenv build for old versions of wget in the wget workflow;
- parallelize make check in the wget workflow;
- shallow clone (+ branch only) where possible;
- document why we are continuing on error for master (now main) branch
  for rsyslog;
- move network manager comment to the top of the step and update the
  master branch to point at main instead. disable systemd too when
  building with meson.
  disable libbf when building on main. libbpf, which is just a
  library to write, load and interact with eBPF programs in the linux
  kernel. unrelated to provider's crypto since it's kernel related and
  not user-space.
- update rsyslog workflow to skip false negatives (happens every other
  runs), added appropriate comments explaining the changes
